### PR TITLE
[#34] Infra: deploy.yml 내 CI/CD job 구조 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,10 @@ on:
       - develop
 
 jobs:
-  deploy:
+  ci:
+    name: Continuous Integration
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +43,12 @@ jobs:
           docker build -t $IMAGE_NAME .
           docker push $IMAGE_NAME
 
+  cd:
+    name: Continuous Deployment
+    runs-on: ubuntu-latest
+    needs: ci
+
+    steps:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.2.2
         with:


### PR DESCRIPTION
## 이슈 번호 (#34)

## 요약
- jobs를 ci, cd로 분리