### PR TITLE
[#54] Refactor: WebClient 비동기(Mono) 기반 처리 변경

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/SubwayService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/SubwayService.kt
@@ -4,12 +4,17 @@ import click.metroeye.api.infrastructure.client.seoul.SeoulSubwayClientAdapter
 import click.metroeye.api.infrastructure.client.seoul.dto.RealtimeArrivalInfo
 import click.metroeye.api.infrastructure.client.seoul.dto.SeoulSubwayApiResponse
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
 
 @Service
 class SubwayService(
     private val seoulSubwayClientAdapter: SeoulSubwayClientAdapter
 ) {
-    fun getArrivalsByStation(startIndex: Int, endIndex: Int, stationName: String): SeoulSubwayApiResponse<List<RealtimeArrivalInfo>> {
+    fun getArrivalsByStation(
+        startIndex: Int,
+        endIndex: Int,
+        stationName: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimeArrivalInfo>>> {
         return seoulSubwayClientAdapter.getArrivalsByStation(startIndex, endIndex, stationName)
     }
 }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/client/common/WebClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/client/common/WebClientAdapter.kt
@@ -7,8 +7,6 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
-import java.net.URI
-import java.nio.charset.StandardCharsets
 
 @Component
 class WebClientAdapter(
@@ -27,24 +25,33 @@ class WebClientAdapter(
         uri: String,
         requestParams: Map<String, Any>,
         responseType: ParameterizedTypeReference<T>
-    ): T? {
-        try {
-            val requestUri: URI = UriComponentsBuilder
-                .fromUriString(uri)
+    ): Mono<T> {
+        val requestUri = try {
+            UriComponentsBuilder.fromUriString(uri)
                 .apply { requestParams.forEach { (key, value) -> queryParam(key, value) } }
                 .encode()
                 .build()
                 .toUri()
-
-            return this.webClient.get()
-                .uri(requestUri)
-                .retrieve()
-                .bodyToMono(responseType)
-                .block()
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             e.printStackTrace()
-            return null
+            return Mono.empty()
         }
+
+        return this.webClient.get()
+            .uri(requestUri)
+            .retrieve()
+            .bodyToMono(responseType)
+            .onErrorResume {
+                logger.error("""
+                    
+                    
+                    |[WEBCLIENT REQUEST ERROR]
+                    |>> METHOD: GET
+                    |>> MESSAGE: ${it.message}
+                """.trimIndent()
+                )
+                Mono.empty()
+            }
     }
 
     private fun requestFilter(): ExchangeFilterFunction {
@@ -54,11 +61,9 @@ class WebClientAdapter(
                 
                 
                 |[WEBCLIENT REQUEST]
-                |>> METHOD: {}
-                |>> URL: {} 
-                """.trimIndent(),
-                request.method(),
-                request.url()
+                |>> METHOD: ${request.method()}
+                |>> URL: ${request.url()} 
+                """.trimIndent()
             )
             Mono.just(request)
         }
@@ -71,9 +76,8 @@ class WebClientAdapter(
                 
                 
                 |[WEBCLIENT RESONSE]
-                |>> STATUS: {}
-                """.trimIndent(),
-                response.statusCode()
+                |>> STATUS: ${response.statusCode()}
+                """.trimIndent()
             )
             Mono.just(response)
         }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/client/seoul/SeoulSubwayClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/client/seoul/SeoulSubwayClientAdapter.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
+import reactor.core.publisher.Mono
 
 @Component
 class SeoulSubwayClientAdapter(
@@ -18,24 +19,26 @@ class SeoulSubwayClientAdapter(
     @Value("\${external-api.seoul-public-data.subway.api-key}")
     private val apiKey: String
 ) {
-    fun getArrivalsByStation(startIndex: Int, endIndex: Int, stationName: String): SeoulSubwayApiResponse<List<RealtimeArrivalInfo>> {
-        val response: String? = webClientAdapter.get(
+    fun getArrivalsByStation(
+        startIndex: Int,
+        endIndex: Int,
+        stationName: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimeArrivalInfo>>> {
+        return webClientAdapter.get(
             "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$stationName",
             requestParams = emptyMap(),
             responseType = object : ParameterizedTypeReference<String>() {}
-        )
-
-        if(StringUtils.hasText(response)) {
+        ).map { response ->
             val jsonNode = objectMapper.readTree(response)
 
-            if(jsonNode.has("errorMessage") && jsonNode.has("realtimeArrivalList")) {
+            if (jsonNode.has("errorMessage") && jsonNode.has("realtimeArrivalList")) {
                 val message = jsonNode.get("errorMessage").get("message").asText()
                 val data = objectMapper.readValue(
                     jsonNode.get("realtimeArrivalList").toString(),
                     object : TypeReference<List<RealtimeArrivalInfo>>() {}
                 )
 
-                return SeoulSubwayApiResponse(
+                SeoulSubwayApiResponse(
                     true,
                     message,
                     data
@@ -43,18 +46,60 @@ class SeoulSubwayClientAdapter(
             } else {
                 val message = jsonNode.get("message").asText()
 
-                return SeoulSubwayApiResponse(
+                SeoulSubwayApiResponse(
                     false,
                     message,
                     null
                 )
             }
         }
-
-        return SeoulSubwayApiResponse(
-            false,
-            "외부 API로부터 빈 응답을 받았습니다.",
-            null
+        .defaultIfEmpty(
+            SeoulSubwayApiResponse(
+                false,
+                "외부 API로부터 빈 응답을 받았습니다.",
+                null
+            )
         )
+
+
+
+
+    //        val response: String? = webClientAdapter.get(
+//            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$stationName",
+//            requestParams = emptyMap(),
+//            responseType = object : ParameterizedTypeReference<String>() {}
+//        ).block()
+
+//        if(StringUtils.hasText(response)) {
+//            val jsonNode = objectMapper.readTree(response)
+//
+//            if(jsonNode.has("errorMessage") && jsonNode.has("realtimeArrivalList")) {
+//                val message = jsonNode.get("errorMessage").get("message").asText()
+//                val data = objectMapper.readValue(
+//                    jsonNode.get("realtimeArrivalList").toString(),
+//                    object : TypeReference<List<RealtimeArrivalInfo>>() {}
+//                )
+//
+//                return SeoulSubwayApiResponse(
+//                    true,
+//                    message,
+//                    data
+//                )
+//            } else {
+//                val message = jsonNode.get("message").asText()
+//
+//                return SeoulSubwayApiResponse(
+//                    false,
+//                    message,
+//                    null
+//                )
+//            }
+//        }
+
+//        return SeoulSubwayApiResponse(
+//            false,
+//            "외부 API로부터 빈 응답을 받았습니다.",
+//            null
+//        )
     }
 }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/client/seoul/dto/SeoulSubwayApiResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/client/seoul/dto/SeoulSubwayApiResponse.kt
@@ -2,7 +2,7 @@ package click.metroeye.api.infrastructure.client.seoul.dto
 
 import org.apache.logging.log4j.message.Message
 
-data class SeoulSubwayApiResponse<T>(
+data class SeoulSubwayApiResponse<out T>(
     val success: Boolean,
     val message: String,
     val data: T?

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/SubwayController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/SubwayController.kt
@@ -7,9 +7,10 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
 
 @RestController
-@RequestMapping("v1/subways")
+@RequestMapping("/v1/subways")
 class SubwayController(
     private val subwayService: SubwayService
 ) {
@@ -18,14 +19,17 @@ class SubwayController(
         @RequestParam(value = "startIndex") startIndex: Int,
         @RequestParam(value = "endIndex") endIndex: Int,
         @RequestParam(value = "station") station: String
-    ): ResponseEntity<Map<String, Any?>> {
-        val subwayApiResponse = subwayService.getArrivalsByStation(startIndex, endIndex, station)
-
-       return ResponseEntity.ok(mapOf(
-            "status" to 200,
-            "client_message" to "조회되었습니다.",
-            "server_message" to "SUCCESS",
-            "data" to subwayApiResponse
-        ))
+    ): Mono<ResponseEntity<Map<String, Any?>>> {
+        return subwayService.getArrivalsByStation(startIndex, endIndex, station)
+            .map { subwayApiResponse ->
+                ResponseEntity.ok(
+                    mapOf(
+                        "status" to 200,
+                        "client_message" to "조회되었습니다.",
+                        "server_message" to "SUCCESS",
+                        "data" to subwayApiResponse
+                    )
+                )
+            }
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#54)

## 요약
- WebClientAdapter에서 block 옵션 제거 및 Mono 추가