### PR TITLE
[#56] Fix: springdoc properties swagger-ui version 제거

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,9 +10,8 @@ external-api:
 
 springdoc:
   default-consumes-media-type: application/json
-  default-produces-media-type: application.json
+  default-produces-media-type: application/json
   swagger-ui:
-    version: v1
     use-root-path: true
     tags-sorter: alpha
     operations-sorter: method
@@ -20,5 +19,5 @@ springdoc:
 
 logging:
   level:
-    click.metroeye.api: debug
+    click.metroeye.api: info
     org.springframework: info


### PR DESCRIPTION
## 이슈 번호 (#56)

## 요약
- springdoc.swagger-ui.version 제거