### PR TITLE
[#72] Feat: infrastructure 하위 패키지 내 어댑터 클래스 생성

### DIFF
--- a/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/adapter/SeoulSubwayClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/adapter/SeoulSubwayClientAdapter.kt
@@ -1,0 +1,107 @@
+package click.metroeye.api.infrastructure.external.seoul.adapter
+
+import click.metroeye.api.infrastructure.http.adapter.WebClientAdapter
+import click.metroeye.api.infrastructure.external.seoul.dto.RealtimeArrivalResponse
+import click.metroeye.api.infrastructure.external.seoul.dto.RealtimePositionResponse
+import click.metroeye.api.infrastructure.external.seoul.dto.SeoulSubwayApiResponse
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class SeoulSubwayClientAdapter(
+    private val webClientAdapter: WebClientAdapter,
+    private val objectMapper: ObjectMapper,
+
+    @Value("\${external-api.seoul-public-data.subway.api-key}")
+    private val apiKey: String
+) {
+    fun getRealtimeArrivalsByStation(
+        startIndex: Int,
+        endIndex: Int,
+        station: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimeArrivalResponse>>> {
+        return webClientAdapter.get(
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$station",
+            requestParams = emptyMap(),
+            responseType = object : ParameterizedTypeReference<String>() {}
+        ).map { response ->
+            val jsonNode = objectMapper.readTree(response)
+
+            if (jsonNode.has("errorMessage") && jsonNode.has("realtimeArrivalList")) {
+                val message = jsonNode.get("errorMessage").get("message").asText()
+                val data = objectMapper.readValue(
+                    jsonNode.get("realtimeArrivalList").toString(),
+                    object : TypeReference<List<RealtimeArrivalResponse>>() {}
+                )
+
+                SeoulSubwayApiResponse(
+                    true,
+                    message,
+                    data
+                )
+            } else {
+                val message = jsonNode.get("message").asText()
+
+                SeoulSubwayApiResponse(
+                    false,
+                    message,
+                    null
+                )
+            }
+        }
+            .defaultIfEmpty(
+                SeoulSubwayApiResponse(
+                    false,
+                    "외부 API로부터 빈 응답을 받았습니다.",
+                    null
+                )
+            )
+    }
+
+    fun getRealtimePositionsByLine(
+        startIndex: Int,
+        endIndex: Int,
+        line: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimePositionResponse>>> {
+        return webClientAdapter.get(
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimePosition/$startIndex/$endIndex/$line",
+            requestParams = emptyMap(),
+            responseType = object : ParameterizedTypeReference<String>() {}
+        ).map { response ->
+            val jsonNode = objectMapper.readTree(response)
+
+            if (jsonNode.has("errorMessage") && jsonNode.has("realtimePositionList")) {
+                val message = jsonNode.get("errorMessage").get("message").asText()
+                val data = objectMapper.readValue(
+                    jsonNode.get("realtimePositionList").toString(),
+                    object : TypeReference<List<RealtimePositionResponse>>() {}
+                )
+
+                SeoulSubwayApiResponse(
+                    true,
+                    message,
+                    data
+                )
+            } else {
+                val message = jsonNode.get("message").asText()
+
+                SeoulSubwayApiResponse(
+                    false,
+                    message,
+                    null
+                )
+            }
+        }
+            .defaultIfEmpty(
+                SeoulSubwayApiResponse(
+                    false,
+                    "외부 API로부터 빈 응답을 받았습니다.",
+                    null
+                )
+            )
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/http/adapter/WebClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/http/adapter/WebClientAdapter.kt
@@ -1,0 +1,39 @@
+package click.metroeye.api.infrastructure.http.adapter
+
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+
+@Component
+class WebClientAdapter(
+    private val webClient: WebClient
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(WebClientAdapter::class.java)
+    }
+
+    fun <T> get(
+        uri: String,
+        requestParams: Map<String, Any>,
+        responseType: ParameterizedTypeReference<T>
+    ): Mono<T> {
+        val requestUri = try {
+            UriComponentsBuilder.fromUriString(uri)
+                .apply { requestParams.forEach { (key, value) -> queryParam(key, value) } }
+                .encode()
+                .build()
+                .toUri()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return Mono.empty()
+        }
+
+        return webClient.get()
+            .uri(requestUri)
+            .retrieve()
+            .bodyToMono(responseType)
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#72)

## 요약
- infrastructure.http.adapter 패키지 내 WebClientAdapter 클래스 생성
- infrastructure.external.seoul.adapter 패키지 내 SeoulSubwayClientAdapter 클래스 생성