### PR TITLE
[#67] Feat: 요청 헤더 유틸 클래스 생성

### DIFF
--- a/src/main/kotlin/click/metroeye/api/util/RequestHeaderUtils.kt
+++ b/src/main/kotlin/click/metroeye/api/util/RequestHeaderUtils.kt
@@ -1,0 +1,35 @@
+package click.metroeye.api.util
+
+import org.springframework.http.server.reactive.ServerHttpRequest
+
+object RequestHeaderUtils {
+    fun getStringHeaders(request: ServerHttpRequest): String {
+        val headers = request.headers
+
+        val headerMap = headers.entries.associate {
+            (key, values) -> key to values.joinToString(",")
+        }
+
+        return headerMap.toString()
+    }
+
+    fun getClientIp(request: ServerHttpRequest): String {
+        val headers = request.headers
+
+        var clientIp: String? = headers.getFirst("X-Forwarded-For")
+            ?: headers.getFirst("Proxy-Client-IP")
+            ?: headers.getFirst("WL-Proxy-Client-IP")
+            ?: headers.getFirst("HTTP_CLIENT_IP")
+            ?: headers.getFirst("HTTP_X_FORWARDED_FOR")
+
+        if (clientIp.isNullOrBlank()) {
+            clientIp = request.remoteAddress?.address?.hostAddress
+        }
+
+        if (!clientIp.isNullOrBlank() && clientIp.contains(",")) {
+            clientIp = clientIp.split(",")[0]
+        }
+
+        return clientIp ?: ""
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#67)

## 요약 번호
- RequestHeaderUtils 클래스 생성
- 요청 헤더 값 전체를 문자열로 반환받는 메서드 생성
- 클라이언트 IP 반환 메서드 생성