### PR TITLE
[#75] Feat: 요청 및 응답 로깅 필터 클래스 생성

### DIFF
--- a/src/main/kotlin/click/metroeye/api/config/FilterConfig.kt
+++ b/src/main/kotlin/click/metroeye/api/config/FilterConfig.kt
@@ -1,0 +1,14 @@
+package click.metroeye.api.config
+
+import click.metroeye.api.filter.LogFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.server.WebFilter
+
+@Configuration
+class FilterConfig {
+    @Bean
+    fun logFilter(): WebFilter {
+        return LogFilter()
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/decorator/CachedContentServerHttpResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/decorator/CachedContentServerHttpResponse.kt
@@ -1,0 +1,55 @@
+package click.metroeye.api.decorator
+
+import org.reactivestreams.Publisher
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.MediaType
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+class CachedContentServerHttpResponse(
+    delegate: ServerHttpResponse
+) : ServerHttpResponseDecorator(delegate) {
+    companion object {
+        private const val MAX_CONTENT_LENGTH = 1024
+    }
+
+    private val cachedContent = StringBuilder()
+    private var totalByteCount = 0
+    private var isLoggable = true
+
+    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void?> {
+        val contentType = headers.contentType
+
+        if (contentType?.includes(MediaType.APPLICATION_JSON) != true) {
+            return super.writeWith(body)
+        }
+
+        val flux = Flux.from(body)
+            .map { buffer ->
+                if (!isLoggable) {
+                    return@map buffer
+                }
+
+                val byteCount = buffer.readableByteCount()
+
+                if (totalByteCount + byteCount > MAX_CONTENT_LENGTH) {
+                    isLoggable = false
+                    cachedContent.clear()
+                    return@map buffer
+                }
+
+                totalByteCount += byteCount
+                val bytes = ByteArray(byteCount)
+                buffer.read(bytes)
+                cachedContent.append(String(bytes, Charsets.UTF_8))
+
+                buffer.factory().wrap(bytes)
+            }
+
+        return super.writeWith(flux)
+    }
+
+    fun getCachedContent(): String = cachedContent.toString()
+}

--- a/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
@@ -1,20 +1,37 @@
 package click.metroeye.api.exception
 
 import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice(basePackages = ["click.metroeye.api.presentation.v1.controller"])
 class ApiExceptionHandler {
-    @ExceptionHandler(value = [
-        ApiException::class
-    ])
-    fun apiException(apiException: ApiException): ResponseEntity<ApiResponse<Void?>> {
-        return ResponseEntity.ok(ApiResponse(
-            apiException.clientMessage,
-            apiException.serverMessage,
-            null
-        ))
+    @ExceptionHandler(Exception::class)
+    fun exception(e: Exception): ResponseEntity<ApiResponse<Void?>> {
+        return when (e) {
+            is ApiException -> {
+                ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(
+                        ApiResponse(
+                            e.clientMessage,
+                            e.serverMessage,
+                            null
+                        )
+                    )
+            }
+
+            else -> {
+                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(
+                        ApiResponse(
+                            "서버 오류가 발생했습니다.",
+                            e.message ?: "UNKNOWN SERVER ERROR",
+                            null
+                        )
+                    )
+            }
+        }
     }
 }

--- a/src/main/kotlin/click/metroeye/api/filter/LogFilter.kt
+++ b/src/main/kotlin/click/metroeye/api/filter/LogFilter.kt
@@ -1,0 +1,48 @@
+package click.metroeye.api.filter
+
+import click.metroeye.api.decorator.CachedContentServerHttpResponse
+import click.metroeye.api.util.RequestHeaderUtils
+import org.slf4j.LoggerFactory
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+class LogFilter : WebFilter {
+    companion object {
+        private val logger = LoggerFactory.getLogger(LogFilter::class.java)
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void?> {
+        logger.info("""
+            
+            
+            |[REQUEST]
+            |>> METHOD: ${exchange.request.method}
+            |>> REQUEST URI: ${exchange.request.uri.path}
+            |>> CLIENT IP: ${RequestHeaderUtils.getClientIp(exchange.request)}
+            |>> HEADERS: ${RequestHeaderUtils.getStringHeaders(exchange.request)}
+            |>> REQUEST PARAM: ${exchange.request.queryParams}
+            """.trimIndent()
+        )
+
+        val cachingResponse = CachedContentServerHttpResponse(exchange.response)
+
+        val mutatedExchange = exchange.mutate()
+            .response(cachingResponse)
+            .build()
+
+        return chain.filter(mutatedExchange)
+            .doFinally {
+                val status = exchange.response.statusCode?.value() ?: 200
+
+                logger.info("""
+            
+            
+                    |[RESPONSE]
+                    |>> STATUS: $status
+                    ${if (status != 200) "|>> RESPONSE BODY: ${cachingResponse.getCachedContent()}" else ""}   
+                    """.trimIndent())
+            }
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#75)

## 요약
- 필터와 관련된 설정 클래스(FilterConfig) 생성
- 로깅 필터 클래스(LogFilter) 생성
- 응답 바디 값을 캐싱하기 위한 클래스(CachedContentServerHttpResponse) 생성
- 예외 핸들러 클래스에서 응답 코드(400, 500) 분기 처리
