### PR TITLE
[#85] Refactor: SeoulSubwayClientAdapter 클래스 메서드 파라미터 이름 변경

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/StationService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/StationService.kt
@@ -14,10 +14,10 @@ class StationService(
     ): Mono<Map<String, Any?>> {
         val startIndex = 1
         val endIndex = 100
-        val station = realtimeStationArrivalRequestModel.station
-        val line = realtimeStationArrivalRequestModel.line
-        val realtimeArrivalResponseMono = seoulSubwayClientAdapter.getRealtimeArrivalsByStation(startIndex, endIndex, station)
-        val realtimePositionResponseMono = seoulSubwayClientAdapter.getRealtimePositionsByLine(startIndex, endIndex, line)
+        val stationName = realtimeStationArrivalRequestModel.stationName
+        val lineName = realtimeStationArrivalRequestModel.lineName
+        val realtimeArrivalResponseMono = seoulSubwayClientAdapter.getRealtimeArrivalsByStation(startIndex, endIndex, stationName)
+        val realtimePositionResponseMono = seoulSubwayClientAdapter.getRealtimePositionsByLine(startIndex, endIndex, lineName)
 
         return Mono.zip(realtimeArrivalResponseMono, realtimePositionResponseMono)
             .map { tuple ->

--- a/src/main/kotlin/click/metroeye/api/application/dto/RealtimeStationArrivalRequestModel.kt
+++ b/src/main/kotlin/click/metroeye/api/application/dto/RealtimeStationArrivalRequestModel.kt
@@ -3,14 +3,14 @@ package click.metroeye.api.application.dto
 import click.metroeye.api.exception.ApiException
 
 class RealtimeStationArrivalRequestModel(
-    val station: String,
-    val line: String
+    val stationName: String,
+    val lineName: String
 ) {
     init {
-        if (line.isBlank()) {
+        if (lineName.isBlank()) {
             throw ApiException(
-                "노선 정보가 누락되었습니다.",
-                "RealtimeStationArrivalRequestModel.line is blank."
+                "노선 이름이 누락되었습니다.",
+                "RealtimeStationArrivalRequestModel.lineName is blank."
             )
         }
     }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/adapter/SeoulSubwayClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/adapter/SeoulSubwayClientAdapter.kt
@@ -22,10 +22,10 @@ class SeoulSubwayClientAdapter(
     fun getRealtimeArrivalsByStation(
         startIndex: Int,
         endIndex: Int,
-        station: String
+        stationName: String
     ): Mono<SeoulSubwayApiResponse<List<RealtimeArrivalResponse>>> {
         return webClientAdapter.get(
-            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$station",
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$stationName",
             requestParams = emptyMap(),
             responseType = object : ParameterizedTypeReference<String>() {}
         ).map { response ->
@@ -65,10 +65,10 @@ class SeoulSubwayClientAdapter(
     fun getRealtimePositionsByLine(
         startIndex: Int,
         endIndex: Int,
-        line: String
+        lineName: String
     ): Mono<SeoulSubwayApiResponse<List<RealtimePositionResponse>>> {
         return webClientAdapter.get(
-            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimePosition/$startIndex/$endIndex/$line",
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimePosition/$startIndex/$endIndex/$lineName",
             requestParams = emptyMap(),
             responseType = object : ParameterizedTypeReference<String>() {}
         ).map { response ->

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
@@ -17,14 +17,14 @@ import reactor.core.publisher.Mono
 class StationController(
     private val subwayService: StationService
 ) {
-    @GetMapping(path = ["/{station}/arrivals/realtime"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping(path = ["/{stationName}/arrivals/realtime"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getRealtimeArrivalsByStation(
-        @PathVariable station: String,
+        @PathVariable stationName: String,
         realtimeStationArrivalRequest: RealtimeStationArrivalRequest
     ): Mono<ResponseEntity<ApiResponse<Map<String, Any?>>>> {
         val realtimeStationArrivalRequestModel = RealtimeStationArrivalRequestModel(
-            station,
-            realtimeStationArrivalRequest.line
+            stationName,
+            realtimeStationArrivalRequest.lineName
         )
 
         return subwayService.getArrivalsByStation(realtimeStationArrivalRequestModel)

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/RealtimeStationArrivalRequest.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/RealtimeStationArrivalRequest.kt
@@ -1,5 +1,5 @@
 package click.metroeye.api.presentation.v1.dto.request
 
 data class RealtimeStationArrivalRequest(
-    val line: String
+    val lineName: String
 )


### PR DESCRIPTION
## 이슈 번호 (#85)

## 요약
- getRealtimeArrivalsByStation 메서드 파라미터 이름 변경(station -> stationName)
- getRealtimePositionsByLine 메서드 파라미터 이름 변경(line -> lineName)
- 관련 메서드 파라미터 이름 일괄 변경