### PR TITLE
[#89] Feat: 기기 등록 및 인증 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
               -e DB_DEV_NAME=${{ secrets.DB_DEV_NAME }} \
               -e DB_DEV_MASTER_USERNAME=${{ secrets.DB_DEV_MASTER_USERNAME }} \
               -e DB_DEV_MASTER_PASSWORD=${{ secrets.DB_DEV_MASTER_PASSWORD }} \
+              -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
               -e SEOUL_SUBWAY_API_KEY=${{ secrets.SEOUL_SUBWAY_API_KEY }} \
               -p 8080:8080 \
               ghcr.io/$LOWER_GHCR_USERNAME/metroeye-backend:dev

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.14")
+	implementation("io.jsonwebtoken:jjwt-api:0.13.0")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
+
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/click/metroeye/api/application/dto/CreateDeviceRequestModel.kt
+++ b/src/main/kotlin/click/metroeye/api/application/dto/CreateDeviceRequestModel.kt
@@ -1,0 +1,34 @@
+package click.metroeye.api.application.dto
+
+import click.metroeye.api.constants.OsType
+import click.metroeye.api.exception.ApiException
+import org.springframework.http.HttpStatus
+
+class CreateDeviceRequestModel private constructor(
+    val uuid: String,
+    val osType: OsType
+) {
+    companion object {
+        fun of(uuid: String, osType: String): CreateDeviceRequestModel {
+            if (uuid.isBlank()) {
+                throw ApiException(
+                    HttpStatus.BAD_REQUEST,
+                    "기기 고유 번호가 누락되었습니다.",
+                    "CreateDeviceRequestModel.uuid is blank."
+                )
+            }
+
+            try {
+                OsType.validate(osType)
+            } catch (e: IllegalArgumentException) {
+                throw ApiException(
+                    HttpStatus.BAD_REQUEST,
+                    e.message ?: "지원하지 않는 OS 유형입니다.",
+                    "CreateDeviceRequestModel.osType is invalid."
+                )
+            }
+
+            return CreateDeviceRequestModel(uuid, OsType.valueOf(osType))
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/application/dto/IssueTokenRequestModel.kt
+++ b/src/main/kotlin/click/metroeye/api/application/dto/IssueTokenRequestModel.kt
@@ -1,0 +1,54 @@
+package click.metroeye.api.application.dto
+
+import click.metroeye.api.constants.GrantType
+import click.metroeye.api.exception.ApiException
+import org.springframework.http.HttpStatus
+
+class IssueTokenRequestModel(
+    val grantType: GrantType,
+    val uuid: String?,
+    val secret: String?,
+    val refreshToken: String?,
+) {
+    companion object {
+        fun of(grantType: String, uuid: String?, secret: String?, refreshToken: String?): IssueTokenRequestModel {
+            try {
+                GrantType.validate(grantType)
+            } catch (e: IllegalArgumentException) {
+                throw ApiException(
+                    HttpStatus.BAD_REQUEST,
+                    e.message ?: "지원하지 않는 인증 유형입니다.",
+                    "IssueTokenRequestModel.uuid or IssueTokenRequestModel.secret is missing."
+                )
+            }
+
+            when (GrantType.valueOf(grantType)) {
+                GrantType.CLIENT_CREDENTIALS -> {
+                    if (uuid.isNullOrBlank() || secret.isNullOrBlank()) {
+                        throw ApiException(
+                            HttpStatus.BAD_REQUEST,
+                            "기기 재인증을 위한 정보(기기 고유 번호, 기기 비밀키)가 누락되었습니다.",
+                            "IssueTokenRequestModel.uuid or IssueTokenRequestModel.secret is missing."
+                        )
+                    }
+                }
+                GrantType.REFRESH_TOKEN -> {
+                    if (refreshToken.isNullOrBlank()) {
+                        throw ApiException(
+                            HttpStatus.BAD_REQUEST,
+                            "엑세스 토큰 갱신을 위한 레프레시 토큰이 누락되었습니다.",
+                            "IssueTokenRequestModel.refreshToken is missing."
+                        )
+                    }
+                }
+            }
+
+            return IssueTokenRequestModel(
+                GrantType.valueOf(grantType),
+                uuid,
+                secret,
+                refreshToken
+            )
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/application/dto/RealtimeStationArrivalRequestModel.kt
+++ b/src/main/kotlin/click/metroeye/api/application/dto/RealtimeStationArrivalRequestModel.kt
@@ -1,6 +1,7 @@
 package click.metroeye.api.application.dto
 
 import click.metroeye.api.exception.ApiException
+import org.springframework.http.HttpStatus
 
 class RealtimeStationArrivalRequestModel(
     val stationName: String,
@@ -9,6 +10,7 @@ class RealtimeStationArrivalRequestModel(
     init {
         if (lineName.isBlank()) {
             throw ApiException(
+                HttpStatus.BAD_REQUEST,
                 "노선 이름이 누락되었습니다.",
                 "RealtimeStationArrivalRequestModel.lineName is blank."
             )

--- a/src/main/kotlin/click/metroeye/api/application/service/AuthService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/AuthService.kt
@@ -1,0 +1,144 @@
+package click.metroeye.api.application.service
+
+import click.metroeye.api.application.dto.IssueTokenRequestModel
+import click.metroeye.api.constants.GrantType
+import click.metroeye.api.domain.Device
+import click.metroeye.api.exception.ApiException
+import click.metroeye.api.infrastructure.crypto.token.JsonWebTokenAdapter
+import click.metroeye.api.infrastructure.persistence.DeviceRepositoryAdapter
+import click.metroeye.api.presentation.v1.dto.response.IssueTokenResponse
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import reactor.core.publisher.Mono
+
+@Service
+class AuthService(
+    private val deviceRepositoryAdapter: DeviceRepositoryAdapter,
+    private val jsonWebTokenAdapter: JsonWebTokenAdapter,
+
+    @Value("\${jwt.secret}")
+    private val jwtSecret: String
+) {
+    @Transactional
+    fun issueToken(issueTokenRequestModel: IssueTokenRequestModel): Mono<IssueTokenResponse> {
+        return when (issueTokenRequestModel.grantType) {
+            GrantType.CLIENT_CREDENTIALS -> {
+                val uuid = issueTokenRequestModel.uuid!!
+                val secret = issueTokenRequestModel.secret!!
+
+                deviceRepositoryAdapter.loadDevice(uuid)
+                    .flatMap { loadedDevice ->
+                        if (!loadedDevice.authenticate(secret)) {
+                            return@flatMap Mono.error(
+                                ApiException(
+                                    HttpStatus.UNAUTHORIZED,
+                                    "인증에 실패했습니다.",
+                                    "Device secret does not match."
+                                )
+                            )
+                        }
+
+                        val accessToken = jsonWebTokenAdapter.generate(
+                            loadedDevice.uuid,
+                            mapOf("type" to "ACCESS"),
+                            Device.ACCESS_TOKEN_EXPIRATION_SECONDS * 1000,
+                            jwtSecret
+                        )
+
+                        val refreshToken = jsonWebTokenAdapter.generate(
+                            loadedDevice.uuid,
+                            mapOf("type" to "REFRESH"),
+                            Device.REFRESH_TOKEN_EXPIRATION_SECONDS * 1000,
+                            jwtSecret
+                        )
+
+                        loadedDevice.updateRefreshToken(refreshToken)
+
+                        deviceRepositoryAdapter.saveDevice(loadedDevice)
+                            .map { savedDevice ->
+                                IssueTokenResponse(
+                                    accessToken,
+                                    refreshToken,
+                                    Device.ACCESS_TOKEN_EXPIRATION_SECONDS
+                                )
+                            }
+                    }
+                    .switchIfEmpty(
+                        Mono.error(
+                            ApiException(
+                                HttpStatus.UNAUTHORIZED,
+                                "인증에 실패했습니다.",
+                                "Device not found."
+                            )
+                        )
+                    )
+            }
+            else -> {
+                val refreshToken = issueTokenRequestModel.refreshToken!!
+
+                val claims = try {
+                    jsonWebTokenAdapter.parseClaims(refreshToken, jwtSecret)
+                } catch (e: ExpiredJwtException) {
+                    throw ApiException(
+                        HttpStatus.UNAUTHORIZED,
+                        "인증에 실패했습니다.",
+                        "Refresh token has expired."
+                    )
+                } catch (e: JwtException) {
+                    throw ApiException(
+                        HttpStatus.UNAUTHORIZED,
+                        "인증에 실패했습니다.",
+                        "Refresh token is invalid."
+                    )
+                }
+
+                val uuid = claims.subject ?: throw ApiException(
+                    HttpStatus.UNAUTHORIZED,
+                    "인증에 실패했습니다.",
+                    "Refresh token subject is missing."
+                )
+
+                deviceRepositoryAdapter.loadDevice(uuid)
+                    .flatMap { loadedDevice ->
+                        if (!loadedDevice.validateRefreshToken(refreshToken)) {
+                            return@flatMap Mono.error(
+                                ApiException(
+                                    HttpStatus.UNAUTHORIZED,
+                                    "인증에 실패했습니다.",
+                                    "Refresh token does not match."
+                                )
+                            )
+                        }
+
+                        val accessToken = jsonWebTokenAdapter.generate(
+                            uuid,
+                            mapOf("type" to "ACCESS"),
+                            Device.ACCESS_TOKEN_EXPIRATION_SECONDS * 1000,
+                            jwtSecret
+                        )
+
+                        Mono.just(
+                            IssueTokenResponse(
+                                accessToken,
+                                refreshToken,
+                                Device.ACCESS_TOKEN_EXPIRATION_SECONDS
+                            )
+                        )
+                    }
+                    .switchIfEmpty(
+                        Mono.error(
+                            ApiException(
+                                HttpStatus.UNAUTHORIZED,
+                                "인증에 실패했습니다.",
+                                "Device not found."
+                            )
+                        )
+                    )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/application/service/DeviceService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/DeviceService.kt
@@ -1,0 +1,71 @@
+package click.metroeye.api.application.service
+
+import click.metroeye.api.application.dto.CreateDeviceRequestModel
+import click.metroeye.api.domain.Device
+import click.metroeye.api.infrastructure.crypto.secret.SecureRandomSecretAdapter
+import click.metroeye.api.infrastructure.crypto.token.JsonWebTokenAdapter
+import click.metroeye.api.infrastructure.persistence.DeviceRepositoryAdapter
+import click.metroeye.api.presentation.v1.dto.response.CreateDeviceResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import reactor.core.publisher.Mono
+
+@Service
+class DeviceService(
+    private val deviceRepositoryAdapter: DeviceRepositoryAdapter,
+    private val secureRandomSecretAdapter: SecureRandomSecretAdapter,
+    private val jsonWebTokenAdapter: JsonWebTokenAdapter,
+
+    @Value("\${jwt.secret}")
+    private val jwtSecret: String
+) {
+    @Transactional
+    fun createDevice(createDeviceRequestModel: CreateDeviceRequestModel): Mono<CreateDeviceResponse> {
+        val uuid = createDeviceRequestModel.uuid
+
+        return deviceRepositoryAdapter.loadDevice(uuid)
+            .flatMap { loadedDevice ->
+                val secret = secureRandomSecretAdapter.generate(32)
+                loadedDevice.updateSecret(secret)
+                issueTokens(loadedDevice)
+            }
+            .switchIfEmpty(
+                Mono.defer {
+                    val uuid = createDeviceRequestModel.uuid
+                    val secret = secureRandomSecretAdapter.generate(32)
+                    val osType = createDeviceRequestModel.osType
+                    val device = Device.create(uuid, secret, osType)
+                    issueTokens(device)
+                }
+            )
+    }
+
+    private fun issueTokens(device: Device): Mono<CreateDeviceResponse> {
+        val accessToken = jsonWebTokenAdapter.generate(
+            device.uuid,
+            mapOf("type" to "ACCESS"),
+            Device.ACCESS_TOKEN_EXPIRATION_SECONDS * 1000,
+            jwtSecret
+        )
+
+        val refreshToken = jsonWebTokenAdapter.generate(
+            device.uuid,
+            mapOf("type" to "REFRESH"),
+            Device.REFRESH_TOKEN_EXPIRATION_SECONDS * 1000,
+            jwtSecret
+        )
+
+        device.updateRefreshToken(refreshToken)
+
+        return deviceRepositoryAdapter.saveDevice(device)
+            .map { savedDevice ->
+                CreateDeviceResponse(
+                    savedDevice.secret,
+                    accessToken,
+                    savedDevice.refreshToken!!,
+                    Device.ACCESS_TOKEN_EXPIRATION_SECONDS
+                )
+            }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/click/metroeye/api/config/SecurityConfig.kt
@@ -1,12 +1,19 @@
 package click.metroeye.api.config
 
+import click.metroeye.api.infrastructure.security.filter.BearerAuthenticationWebFilter
+import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers
+import reactor.core.publisher.Mono
 
 @Configuration
 @EnableWebFluxSecurity
@@ -22,6 +29,8 @@ class SecurityConfig {
                 "/v3/api-docs/**"
             ))
             .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
             .authorizeExchange {
                 it.pathMatchers(
                     "/",
@@ -35,15 +44,41 @@ class SecurityConfig {
 
     @Bean
     @Order(2)
-    fun apiSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+    fun apiSecurityFilterChain(
+        http: ServerHttpSecurity,
+        bearerAuthenticationWebFilter: BearerAuthenticationWebFilter,
+        objectMapper: ObjectMapper
+    ): SecurityWebFilterChain {
         return http
             .securityMatcher(ServerWebExchangeMatchers.pathMatchers(
-                "/v1/subways/**"
+                "/v1/stations/**"
             ))
             .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
             .authorizeExchange {
-                it.anyExchange().permitAll()
+                it.anyExchange().authenticated()
             }
+            .exceptionHandling {
+                it.authenticationEntryPoint { exchange, exception ->
+                    val response = exchange.response
+                    response.statusCode = HttpStatus.UNAUTHORIZED
+                    response.headers.contentType = MediaType.APPLICATION_JSON
+                    val apiResponse = ApiResponse(
+                        "인증에 실패했습니다.",
+                        "Access token is missing.",
+                        null
+                    )
+
+                    val bytes = objectMapper.writeValueAsBytes(apiResponse)
+                    val buffer = response.bufferFactory().wrap(bytes)
+                    response.writeWith(Mono.just(buffer))
+                }
+            }
+            .addFilterAt(
+                bearerAuthenticationWebFilter,
+                SecurityWebFiltersOrder.AUTHENTICATION
+            )
             .build()
     }
 }

--- a/src/main/kotlin/click/metroeye/api/constants/GrantType.kt
+++ b/src/main/kotlin/click/metroeye/api/constants/GrantType.kt
@@ -1,0 +1,18 @@
+package click.metroeye.api.constants
+
+enum class GrantType {
+    CLIENT_CREDENTIALS,
+    REFRESH_TOKEN;
+
+    companion object {
+        fun validate(value: String?) {
+            val isValid = entries.any {
+                it.name.equals(value, ignoreCase = true)
+            }
+
+            if (!isValid) {
+                throw IllegalArgumentException("지원하지 않는 인증 유형입니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/constants/OsType.kt
+++ b/src/main/kotlin/click/metroeye/api/constants/OsType.kt
@@ -1,0 +1,18 @@
+package click.metroeye.api.constants
+
+enum class OsType {
+    ANDROID,
+    IOS;
+
+    companion object {
+        fun validate(value: String?) {
+            val isValid = entries.any {
+                it.name.equals(value, ignoreCase = true)
+            }
+
+            if (!isValid) {
+                throw IllegalArgumentException("지원하지 않는 OS 유형입니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/domain/Device.kt
+++ b/src/main/kotlin/click/metroeye/api/domain/Device.kt
@@ -1,0 +1,46 @@
+package click.metroeye.api.domain
+
+import click.metroeye.api.constants.OsType
+
+class Device private constructor(
+    val idx: Long?,
+    val uuid: String,
+    var secret: String,
+    val osType: OsType,
+    var refreshToken: String? = null
+) {
+    companion object {
+        const val ACCESS_TOKEN_EXPIRATION_SECONDS = 30 * 60L
+        const val REFRESH_TOKEN_EXPIRATION_SECONDS = 60 * 60 * 24 * 30L
+
+        fun create(uuid: String, secret: String, osType: OsType): Device {
+            return Device(null, uuid, secret, osType)
+        }
+
+        fun of(idx: Long?, uuid: String, secret: String, osType: String, refreshToken: String?): Device {
+            return Device(
+                idx,
+                uuid,
+                secret,
+                OsType.valueOf(osType),
+                refreshToken
+            )
+        }
+    }
+
+    fun authenticate(secret: String): Boolean {
+        return this.secret == secret
+    }
+
+    fun validateRefreshToken(refreshToken: String): Boolean {
+        return this.refreshToken == refreshToken
+    }
+
+    fun updateSecret(secret: String) {
+        this.secret = secret
+    }
+
+    fun updateRefreshToken(refreshToken: String) {
+        this.refreshToken = refreshToken
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/exception/ApiException.kt
+++ b/src/main/kotlin/click/metroeye/api/exception/ApiException.kt
@@ -1,6 +1,9 @@
 package click.metroeye.api.exception
 
+import org.springframework.http.HttpStatus
+
 class ApiException(
+    val status: HttpStatus,
     val clientMessage: String,
     val serverMessage: String
 ) : RuntimeException(serverMessage) {}

--- a/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
@@ -12,7 +12,7 @@ class ApiExceptionHandler {
     fun exception(e: Exception): ResponseEntity<ApiResponse<Void?>> {
         return when (e) {
             is ApiException -> {
-                ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                ResponseEntity.status(e.status)
                     .body(
                         ApiResponse(
                             e.clientMessage,
@@ -27,7 +27,7 @@ class ApiExceptionHandler {
                     .body(
                         ApiResponse(
                             "서버 오류가 발생했습니다.",
-                            e.message ?: "UNKNOWN SERVER ERROR",
+                            e.message ?: "Unknown server error.",
                             null
                         )
                     )

--- a/src/main/kotlin/click/metroeye/api/infrastructure/crypto/secret/SecureRandomSecretAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/crypto/secret/SecureRandomSecretAdapter.kt
@@ -1,0 +1,17 @@
+package click.metroeye.api.infrastructure.crypto.secret
+
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.util.*
+
+@Component
+class SecureRandomSecretAdapter {
+    private val secureRandom = SecureRandom()
+    private val base64Encoder = Base64.getUrlEncoder().withoutPadding()
+
+    fun generate(byteLength: Int = 24): String {
+        val bytes = ByteArray(byteLength)
+        secureRandom.nextBytes(bytes)
+        return base64Encoder.encodeToString(bytes)
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/crypto/token/JsonWebTokenAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/crypto/token/JsonWebTokenAdapter.kt
@@ -1,0 +1,40 @@
+package click.metroeye.api.infrastructure.crypto.token
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class JsonWebTokenAdapter {
+    fun generate(
+        subject: String,
+        claims: Map<String, Any>,
+        expirationMillis: Long,
+        secret: String
+    ): String {
+        val currentDate = Date()
+        val expirationDate = Date(currentDate.time + expirationMillis)
+        val signingKey = Keys.hmacShaKeyFor(secret.toByteArray())
+
+        return Jwts.builder()
+            .header().add("typ", "JWT").and()
+            .subject(subject)
+            .claims(claims)
+            .issuedAt(currentDate)
+            .expiration(expirationDate)
+            .signWith(signingKey)
+            .compact()
+    }
+
+    fun parseClaims(token: String, secret: String): Claims {
+        val signingKey = Keys.hmacShaKeyFor(secret.toByteArray())
+
+        return Jwts.parser()
+            .verifyWith(signingKey)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/external/common/WebClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/external/common/WebClientAdapter.kt
@@ -1,0 +1,39 @@
+package click.metroeye.api.infrastructure.external.common
+
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+
+@Component
+class WebClientAdapter(
+    private val webClient: WebClient
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(WebClientAdapter::class.java)
+    }
+
+    fun <T> get(
+        uri: String,
+        requestParams: Map<String, Any>,
+        responseType: ParameterizedTypeReference<T>
+    ): Mono<T> {
+        val requestUri = try {
+            UriComponentsBuilder.fromUriString(uri)
+                .apply { requestParams.forEach { (key, value) -> queryParam(key, value) } }
+                .encode()
+                .build()
+                .toUri()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return Mono.empty()
+        }
+
+        return webClient.get()
+            .uri(requestUri)
+            .retrieve()
+            .bodyToMono(responseType)
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/SeoulSubwayClientAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/external/seoul/SeoulSubwayClientAdapter.kt
@@ -1,0 +1,107 @@
+package click.metroeye.api.infrastructure.external.seoul
+
+import click.metroeye.api.infrastructure.external.common.WebClientAdapter
+import click.metroeye.api.infrastructure.external.seoul.dto.RealtimeArrivalResponse
+import click.metroeye.api.infrastructure.external.seoul.dto.RealtimePositionResponse
+import click.metroeye.api.infrastructure.external.seoul.dto.SeoulSubwayApiResponse
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class SeoulSubwayClientAdapter(
+    private val webClientAdapter: WebClientAdapter,
+    private val objectMapper: ObjectMapper,
+
+    @Value("\${external-api.seoul-public-data.subway.api-key}")
+    private val apiKey: String
+) {
+    fun getRealtimeArrivalsByStation(
+        startIndex: Int,
+        endIndex: Int,
+        stationName: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimeArrivalResponse>>> {
+        return webClientAdapter.get(
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimeStationArrival/$startIndex/$endIndex/$stationName",
+            requestParams = emptyMap(),
+            responseType = object : ParameterizedTypeReference<String>() {}
+        ).map { response ->
+            val jsonNode = objectMapper.readTree(response)
+
+            if (jsonNode.has("errorMessage") && jsonNode.has("realtimeArrivalList")) {
+                val message = jsonNode.get("errorMessage").get("message").asText()
+                val data = objectMapper.readValue(
+                    jsonNode.get("realtimeArrivalList").toString(),
+                    object : TypeReference<List<RealtimeArrivalResponse>>() {}
+                )
+
+                SeoulSubwayApiResponse(
+                    true,
+                    message,
+                    data
+                )
+            } else {
+                val message = jsonNode.get("message").asText()
+
+                SeoulSubwayApiResponse(
+                    false,
+                    message,
+                    null
+                )
+            }
+        }
+            .defaultIfEmpty(
+                SeoulSubwayApiResponse(
+                    false,
+                    "외부 API로부터 빈 응답을 받았습니다.",
+                    null
+                )
+            )
+    }
+
+    fun getRealtimePositionsByLine(
+        startIndex: Int,
+        endIndex: Int,
+        lineName: String
+    ): Mono<SeoulSubwayApiResponse<List<RealtimePositionResponse>>> {
+        return webClientAdapter.get(
+            "http://swopenapi.seoul.go.kr/api/subway/$apiKey/json/realtimePosition/$startIndex/$endIndex/$lineName",
+            requestParams = emptyMap(),
+            responseType = object : ParameterizedTypeReference<String>() {}
+        ).map { response ->
+            val jsonNode = objectMapper.readTree(response)
+
+            if (jsonNode.has("errorMessage") && jsonNode.has("realtimePositionList")) {
+                val message = jsonNode.get("errorMessage").get("message").asText()
+                val data = objectMapper.readValue(
+                    jsonNode.get("realtimePositionList").toString(),
+                    object : TypeReference<List<RealtimePositionResponse>>() {}
+                )
+
+                SeoulSubwayApiResponse(
+                    true,
+                    message,
+                    data
+                )
+            } else {
+                val message = jsonNode.get("message").asText()
+
+                SeoulSubwayApiResponse(
+                    false,
+                    message,
+                    null
+                )
+            }
+        }
+            .defaultIfEmpty(
+                SeoulSubwayApiResponse(
+                    false,
+                    "외부 API로부터 빈 응답을 받았습니다.",
+                    null
+                )
+            )
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/DeviceRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/DeviceRepositoryAdapter.kt
@@ -1,0 +1,46 @@
+package click.metroeye.api.infrastructure.persistence
+
+import click.metroeye.api.domain.Device
+import click.metroeye.api.infrastructure.persistence.entity.DeviceEntity
+import click.metroeye.api.infrastructure.persistence.repository.DeviceRepository
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Mono
+
+@Repository
+class DeviceRepositoryAdapter(
+    private val deviceRepository: DeviceRepository
+) {
+    fun loadDevice(uuid: String): Mono<Device> {
+        return deviceRepository.findByUuid(uuid)
+            .map { deviceEntity ->
+                Device.of(
+                    deviceEntity.idx,
+                    deviceEntity.uuid,
+                    deviceEntity.secret,
+                    deviceEntity.osType,
+                    deviceEntity.refreshToken
+                )
+            }
+    }
+
+    fun saveDevice(device: Device): Mono<Device> {
+        val deviceEntity = DeviceEntity(
+            device.idx,
+            device.uuid,
+            device.secret,
+            device.osType.name,
+            device.refreshToken
+        )
+
+        return deviceRepository.save(deviceEntity)
+            .map { savedDeviceEntity ->
+                Device.of(
+                    savedDeviceEntity.idx,
+                    savedDeviceEntity.uuid,
+                    savedDeviceEntity.secret,
+                    savedDeviceEntity.osType,
+                    savedDeviceEntity.refreshToken
+                )
+            }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/DeviceEntity.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/DeviceEntity.kt
@@ -1,0 +1,27 @@
+package click.metroeye.api.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.ReadOnlyProperty
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+
+@Table("DEVICES")
+data class DeviceEntity(
+    @Id
+    @Column("idx")
+    val idx: Long? = null,
+    @Column("uuid")
+    val uuid: String,
+    @Column("secret")
+    val secret: String,
+    @Column("os_type")
+    val osType: String,
+    @Column("refresh_token")
+    val refreshToken: String? = null,
+    @Column("created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    @ReadOnlyProperty
+    @Column("updated_at")
+    val updatedAt: LocalDateTime? = null
+)

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/repository/DeviceRepository.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/repository/DeviceRepository.kt
@@ -1,0 +1,9 @@
+package click.metroeye.api.infrastructure.persistence.repository
+
+import click.metroeye.api.infrastructure.persistence.entity.DeviceEntity
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Mono
+
+interface DeviceRepository: ReactiveCrudRepository<DeviceEntity, Long> {
+    fun findByUuid(uuid: String): Mono<DeviceEntity>
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/security/filter/BearerAuthenticationWebFilter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/security/filter/BearerAuthenticationWebFilter.kt
@@ -1,0 +1,57 @@
+package click.metroeye.api.infrastructure.security.filter
+
+import click.metroeye.api.infrastructure.security.manager.BearerAuthenticationManager
+import click.metroeye.api.infrastructure.security.token.BearerAuthenticationToken
+import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class BearerAuthenticationWebFilter(
+    private val bearerAuthenticationManager: BearerAuthenticationManager,
+    private val objectMapper: ObjectMapper
+) : AuthenticationWebFilter(bearerAuthenticationManager) {
+    init {
+        setServerAuthenticationConverter(bearerAuthenticationConverter())
+        setAuthenticationFailureHandler { webFilterExchange, exception ->
+            val exchange = webFilterExchange.exchange
+            val response = exchange.response
+            response.statusCode = HttpStatus.UNAUTHORIZED
+            response.headers.contentType = MediaType.APPLICATION_JSON
+
+            val apiResponse = ApiResponse(
+                "인증에 실패했습니다.",
+                exception.message ?: "Authentication failed.",
+                null
+            )
+
+            val bytes = objectMapper.writeValueAsBytes(apiResponse)
+            val buffer = response.bufferFactory().wrap(bytes)
+
+            response.writeWith(Mono.just(buffer))
+        }
+    }
+
+    private fun bearerAuthenticationConverter(): ServerAuthenticationConverter {
+        return ServerAuthenticationConverter { exchange ->
+            val headers = exchange.request.headers
+            val authenticationHeader = headers.getFirst(HttpHeaders.AUTHORIZATION)
+
+            if (authenticationHeader == null || !authenticationHeader.startsWith("Bearer ")) {
+                return@ServerAuthenticationConverter Mono.empty()
+            }
+
+            val accessToken = authenticationHeader.removePrefix("Bearer ").trim()
+
+            Mono.just(
+                BearerAuthenticationToken(accessToken)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/security/manager/BearerAuthenticationManager.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/security/manager/BearerAuthenticationManager.kt
@@ -1,0 +1,58 @@
+package click.metroeye.api.infrastructure.security.manager
+
+import click.metroeye.api.infrastructure.crypto.token.JsonWebTokenAdapter
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.ReactiveAuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+    class BearerAuthenticationManager(
+    private val jsonWebTokenAdapter: JsonWebTokenAdapter,
+
+    @Value("\${jwt.secret}")
+    private val jwtSecret: String
+) : ReactiveAuthenticationManager {
+    override fun authenticate(authentication: Authentication): Mono<Authentication> {
+        val accessToken = authentication.credentials as String
+
+        val claims = try {
+            jsonWebTokenAdapter.parseClaims(accessToken, jwtSecret)
+        } catch (e: ExpiredJwtException) {
+            return Mono.error(
+                BadCredentialsException("Access token has expired.")
+            )
+        } catch (e: JwtException) {
+            return Mono.error(
+                BadCredentialsException("Access token is invalid.")
+            )
+        }
+
+        val uuid = claims.subject ?: return Mono.error(
+            BadCredentialsException("Access token subject is missing.")
+        )
+
+        val tokenType = claims["type"] as? String ?: return Mono.error(
+            BadCredentialsException("Token type is missing.")
+        )
+
+        if (tokenType != "ACCESS") {
+            return Mono.error(
+                BadCredentialsException("Token is not an access token.")
+            )
+        }
+
+        return Mono.just(
+            UsernamePasswordAuthenticationToken(
+                uuid,
+                null,
+                emptyList()
+            )
+        )
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/security/token/BearerAuthenticationToken.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/security/token/BearerAuthenticationToken.kt
@@ -1,0 +1,14 @@
+package click.metroeye.api.infrastructure.security.token
+
+import org.springframework.security.authentication.AbstractAuthenticationToken
+
+class BearerAuthenticationToken(
+    private val token: String
+) : AbstractAuthenticationToken(null) {
+    override fun getCredentials(): Any = token
+    override fun getPrincipal(): Any? = null
+
+    init {
+        isAuthenticated = false
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/AuthController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/AuthController.kt
@@ -1,0 +1,50 @@
+package click.metroeye.api.presentation.v1.controller
+
+import click.metroeye.api.application.dto.IssueTokenRequestModel
+import click.metroeye.api.application.service.AuthService
+import click.metroeye.api.presentation.v1.dto.request.IssueTokenRequest
+import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import click.metroeye.api.presentation.v1.dto.response.IssueTokenResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/v1/auth")
+@Tag(name = "Auth API", description = "인증 API")
+class AuthController(
+    private val authService: AuthService
+) {
+    @Operation(
+        summary = "토큰 발급 API",
+        method = "POST",
+        description = "인증 유형에 따른 토큰을 발급합니다."
+    )
+    @PostMapping("/token")
+    fun issueToken(
+        @RequestBody issueTokenRequest: IssueTokenRequest
+    ): Mono<ResponseEntity<ApiResponse<IssueTokenResponse>>> {
+        val issueTokenRequestModel = IssueTokenRequestModel.of(
+            issueTokenRequest.grantType,
+            issueTokenRequest.uuid,
+            issueTokenRequest.secret,
+            issueTokenRequest.refreshToken
+        )
+
+        return authService.issueToken(issueTokenRequestModel)
+            .map { issueTokenResponse ->
+                ResponseEntity.ok(
+                    ApiResponse(
+                        "갱신되었습니다.",
+                        "SUCCESS",
+                        issueTokenResponse
+                    )
+                )
+            }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/DeviceController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/DeviceController.kt
@@ -1,0 +1,45 @@
+package click.metroeye.api.presentation.v1.controller
+
+import click.metroeye.api.application.service.DeviceService
+import click.metroeye.api.application.dto.CreateDeviceRequestModel
+import click.metroeye.api.presentation.v1.dto.request.CreateDeviceRequest
+import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import click.metroeye.api.presentation.v1.dto.response.CreateDeviceResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/v1/devices")
+@Tag(name = "Device API", description = "기기 API")
+class DeviceController(
+    private val deviceService: DeviceService
+) {
+    @Operation(
+        summary = "신규 기기 등록 및 인증 토큰 발급 API",
+        method = "POST",
+        description = "신규 기기를 등록하고 인증 토큰을 발급합니다."
+    )
+    @PostMapping
+    fun createDevice(
+        @RequestBody createDeviceRequest: CreateDeviceRequest
+    ): Mono<ResponseEntity<ApiResponse<CreateDeviceResponse>>> {
+        val createDeviceRequestModel = CreateDeviceRequestModel.of(createDeviceRequest.uuid, createDeviceRequest.osType)
+
+        return deviceService.createDevice(createDeviceRequestModel)
+            .map { createDeviceResponse ->
+                ResponseEntity.ok(
+                    ApiResponse(
+                        "등록되었습니다.",
+                        "SUCCESS",
+                        createDeviceResponse
+                    )
+                )
+            }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/CreateDeviceRequest.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/CreateDeviceRequest.kt
@@ -1,0 +1,10 @@
+package click.metroeye.api.presentation.v1.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreateDeviceRequest(
+    @Schema(description = "기기 고유 번호")
+    val uuid: String,
+    @Schema(description = "OS 유형(ANDROID, IOS)")
+    val osType: String
+)

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/IssueTokenRequest.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/request/IssueTokenRequest.kt
@@ -1,0 +1,14 @@
+package click.metroeye.api.presentation.v1.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class IssueTokenRequest(
+    @Schema(description = "인증 유형(CLIENT_CREDENTIALS, REFRESH_TOKEN)")
+    val grantType: String,
+    @Schema(description = "기기 고유 번호", required = false)
+    val uuid: String?,
+    @Schema(description = "기기 비밀키", required = false)
+    val secret: String?,
+    @Schema(description = "리프레시 토큰", required = false)
+    val refreshToken: String?
+)

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/ApiResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/ApiResponse.kt
@@ -3,5 +3,5 @@ package click.metroeye.api.presentation.v1.dto.response
 data class ApiResponse<T>(
     val clientMessage: String?,
     val serverMessage: String,
-    val data: T
+    val data: T?
 )

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/CreateDeviceResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/CreateDeviceResponse.kt
@@ -1,0 +1,8 @@
+package click.metroeye.api.presentation.v1.dto.response
+
+data class CreateDeviceResponse(
+    val secret: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Long
+)

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/IssueTokenResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/IssueTokenResponse.kt
@@ -1,0 +1,7 @@
+package click.metroeye.api.presentation.v1.dto.response
+
+data class IssueTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Long
+)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ spring:
         max-life-time: 60m
         validation-query: SELECT 1
 
+jwt:
+  secret: ${JWT_SECRET}
+
 external-api:
   seoul-public-data:
     subway:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,5 +8,6 @@ logging:
   level:
     click.metroeye.api: debug
     org.springframework: info
-    o.r2dbc.mysql: debug
-    io.r2dbc.pool: debug
+#    org.springframework.r2dbc: debug
+#    io.r2dbc.pool: debug
+#    io.asyncer.r2dbc.mysql: debug


### PR DESCRIPTION
## 이슈 번호 (#89)

## 요약
- 기기 등록 및 인증 관련 Controller, Service 클래스 구현
- 기기 정보를 조회하고 등록 및 수정하기 위한 Repository 클래스 구현
- 기기 비밀키 생성 구현체 클래스 구현
- 인증 토큰 생성하고 검증하기 위한 JWT 구현체 클래스 구현
- API 요청 시 엑세스 토큰 헤더 값을 검증하도록 BearerAuthenticationManager 클래스 내 authenticate 메서드 개선