### PR TITLE
[#105] Fix: 엔티티 객체 및 도메인 객체 컬럼 이름 변경

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/LineService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/LineService.kt
@@ -16,9 +16,9 @@ class LineService(
             .map { loadedLines ->
                 loadedLines.map { loadedLine ->
                     LineResponse(
-                        loadedLine.idx,
+                        loadedLine.id,
                         loadedLine.name,
-                        loadedLine.code,
+                        loadedLine.externalCode,
                         loadedLine.color
                     )
                 }

--- a/src/main/kotlin/click/metroeye/api/domain/Device.kt
+++ b/src/main/kotlin/click/metroeye/api/domain/Device.kt
@@ -3,7 +3,7 @@ package click.metroeye.api.domain
 import click.metroeye.api.constants.OsType
 
 class Device private constructor(
-    val idx: Long?,
+    val id: Long?,
     val uuid: String,
     var secret: String,
     val osType: OsType,
@@ -17,9 +17,9 @@ class Device private constructor(
             return Device(null, uuid, secret, osType)
         }
 
-        fun of(idx: Long?, uuid: String, secret: String, osType: String, refreshToken: String?): Device {
+        fun of(id: Long?, uuid: String, secret: String, osType: String, refreshToken: String?): Device {
             return Device(
-                idx,
+                id,
                 uuid,
                 secret,
                 OsType.valueOf(osType),

--- a/src/main/kotlin/click/metroeye/api/domain/Line.kt
+++ b/src/main/kotlin/click/metroeye/api/domain/Line.kt
@@ -1,9 +1,9 @@
 package click.metroeye.api.domain
 
 class Line(
-    val idx: Long?,
+    val id: Long?,
     val name: String,
-    val code: String,
+    val externalCode: String,
     val color: String
 ) {
 }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/DeviceRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/DeviceRepositoryAdapter.kt
@@ -14,7 +14,7 @@ class DeviceRepositoryAdapter(
         return deviceRepository.findByUuid(uuid)
             .map { loadedDeviceEntity ->
                 Device.of(
-                    loadedDeviceEntity.idx,
+                    loadedDeviceEntity.id,
                     loadedDeviceEntity.uuid,
                     loadedDeviceEntity.secret,
                     loadedDeviceEntity.osType,
@@ -25,7 +25,7 @@ class DeviceRepositoryAdapter(
 
     fun saveDevice(device: Device): Mono<Device> {
         val deviceEntity = DeviceEntity(
-            device.idx,
+            device.id,
             device.uuid,
             device.secret,
             device.osType.name,
@@ -35,7 +35,7 @@ class DeviceRepositoryAdapter(
         return deviceRepository.save(deviceEntity)
             .map { savedDeviceEntity ->
                 Device.of(
-                    savedDeviceEntity.idx,
+                    savedDeviceEntity.id,
                     savedDeviceEntity.uuid,
                     savedDeviceEntity.secret,
                     savedDeviceEntity.osType,

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/LineRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/LineRepositoryAdapter.kt
@@ -13,7 +13,7 @@ class LineRepositoryAdapter(
         return lineRepository.findAllByOrderByDisplayOrderAsc()
             .map { loadedLineEntity ->
                 Line(
-                    loadedLineEntity.idx,
+                    loadedLineEntity.id,
                     loadedLineEntity.name,
                     loadedLineEntity.code,
                     loadedLineEntity.color

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/DeviceEntity.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/DeviceEntity.kt
@@ -6,11 +6,11 @@ import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 
-@Table("DEVICES")
+@Table("devices")
 data class DeviceEntity(
     @Id
-    @Column("idx")
-    val idx: Long? = null,
+    @Column("id")
+    val id: Long? = null,
     @Column("uuid")
     val uuid: String,
     @Column("secret")

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/LineEntity.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/LineEntity.kt
@@ -6,11 +6,11 @@ import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 
-@Table("`LINES`")
+@Table("lines")
 data class LineEntity(
     @Id
-    @Column("idx")
-    val idx: Long? = null,
+    @Column("id")
+    val id: Long? = null,
     @Column("name")
     val name: String,
     @Column("code")

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/LineResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/LineResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "호선 응답 객체")
 data class LineResponse(
     @field:Schema(description = "호선 ID")
-    val idx: Long?,
+    val id: Long?,
     @field:Schema(description = "호선 이름")
     val name: String,
     @field:Schema(description = "호선 코드")


### PR DESCRIPTION
## 이슈 번호 (#105)

## 요약
- DeviceEntity, LineEntity 객체의 테이블 및 컬럼 이름 변경
- Device, Line 객체의 컬럼 이름 변경