### PR TITLE
[#109] Fix: lines 테이블명 백틱 적용

### DIFF
--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/LineEntity.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/entity/LineEntity.kt
@@ -6,7 +6,7 @@ import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 
-@Table("lines")
+@Table("`lines`")
 data class LineEntity(
     @Id
     @Column("id")


### PR DESCRIPTION
## 이슈 번호 (#109)

## 요약
- lines 테이블명에 백틱 적용