### PR TITLE
[#111] Feat: 역 목록 조회를 위한 stations API를 개발

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/StationService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/StationService.kt
@@ -1,0 +1,98 @@
+package click.metroeye.api.application.service
+
+import click.metroeye.api.domain.Station
+import click.metroeye.api.infrastructure.persistence.StationQueryRepository
+import click.metroeye.api.presentation.v1.dto.response.StationResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@Service
+class StationService(
+    private val stationQueryRepository: StationQueryRepository
+) {
+    companion object {
+        private const val LINE_SUFFIX = "호선"
+    }
+
+    @Transactional(readOnly = true)
+    fun getStations(line: String?): Mono<List<StationResponse>> {
+        val trimmedLine = line?.trim().orEmpty()
+
+        return if (trimmedLine.isNotEmpty()) {
+            getStationsByLine(trimmedLine)
+        } else {
+            stationQueryRepository.loadStations()
+                .map { it.toResponse() }
+                .collectList()
+        }
+    }
+
+    private fun getStationsByLine(lineInput: String): Mono<List<StationResponse>> {
+        val lineKeys = buildLineKeyCandidates(lineInput)
+        val lineId = lineInput.toLongOrNull()
+
+        val stationsById = if (lineId != null) {
+            stationQueryRepository.loadStationsByLineId(lineId)
+        } else {
+            Flux.empty()
+        }
+
+        return stationsById.collectList()
+            .flatMap { stations ->
+                if (stations.isNotEmpty()) {
+                    Mono.just(stations)
+                } else {
+                    loadStationsByLineKeys(lineKeys).collectList()
+                }
+            }
+            .map { stations -> stations.map { it.toResponse() } }
+    }
+
+    private fun loadStationsByLineKeys(lineKeys: List<String>): Flux<Station> {
+        if (lineKeys.isEmpty()) {
+            return Flux.empty()
+        }
+
+        return Flux.fromIterable(lineKeys)
+            .concatMap { lineKey -> stationQueryRepository.loadStationsByLineKey(lineKey) }
+            .distinct { "${it.lineId}:${it.stationCode}" }
+    }
+
+    private fun buildLineKeyCandidates(lineInput: String): List<String> {
+        val trimmedLine = lineInput.trim()
+        if (trimmedLine.isEmpty()) {
+            return emptyList()
+        }
+
+        val candidates = LinkedHashSet<String>()
+        candidates.add(trimmedLine)
+
+        val withoutSuffix = trimmedLine.removeSuffix(LINE_SUFFIX)
+        if (withoutSuffix != trimmedLine) {
+            candidates.add(withoutSuffix)
+        }
+
+        if (withoutSuffix.all { it.isDigit() }) {
+            val padded = withoutSuffix.padStart(2, '0')
+            candidates.add(padded)
+            candidates.add("${withoutSuffix}$LINE_SUFFIX")
+            candidates.add("$padded$LINE_SUFFIX")
+            if (withoutSuffix.length <= 2) {
+                candidates.add("10$padded")
+            }
+        }
+
+        return candidates.toList()
+    }
+
+    private fun Station.toResponse(): StationResponse {
+        return StationResponse(
+            name = name,
+            stationCode = stationCode,
+            lineId = lineId,
+            lineName = lineName
+        )
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/domain/Station.kt
+++ b/src/main/kotlin/click/metroeye/api/domain/Station.kt
@@ -1,0 +1,11 @@
+package click.metroeye.api.domain
+
+class Station(
+    val id: Long,
+    val name: String,
+    val stationCode: String,
+    val externalCode: String,
+    val lineId: Long,
+    val lineName: String,
+    val lineCode: String
+)

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationQueryRepository.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationQueryRepository.kt
@@ -1,0 +1,100 @@
+package click.metroeye.api.infrastructure.persistence
+
+import click.metroeye.api.domain.Station
+import io.r2dbc.spi.Row
+import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
+
+@Repository
+class StationQueryRepository(
+    private val databaseClient: DatabaseClient
+) {
+    fun loadStations(): Flux<Station> {
+        return databaseClient.sql(
+            """
+                SELECT
+                    s.id AS station_id,
+                    s.name AS station_name,
+                    ls.station_code AS station_code,
+                    ls.fr_code AS fr_code,
+                    l.id AS line_id,
+                    l.name AS line_name,
+                    l.code AS line_code
+                FROM `line_stations` ls
+                INNER JOIN `stations` s ON s.id = ls.station_id
+                INNER JOIN `lines` l ON l.id = ls.line_id
+                ORDER BY l.display_order ASC, ls.id ASC
+            """.trimIndent()
+        )
+            .map { row, _ -> mapRow(row) }
+            .all()
+    }
+
+    fun loadStationsByLineId(lineId: Long): Flux<Station> {
+        return databaseClient.sql(
+            """
+                SELECT
+                    s.id AS station_id,
+                    s.name AS station_name,
+                    ls.station_code AS station_code,
+                    ls.fr_code AS fr_code,
+                    l.id AS line_id,
+                    l.name AS line_name,
+                    l.code AS line_code
+                FROM `line_stations` ls
+                INNER JOIN `stations` s ON s.id = ls.station_id
+                INNER JOIN `lines` l ON l.id = ls.line_id
+                WHERE l.id = ?
+                ORDER BY ls.id ASC
+            """.trimIndent()
+        )
+            .bind(0, lineId)
+            .map { row, _ -> mapRow(row) }
+            .all()
+    }
+
+    fun loadStationsByLineKey(lineKey: String): Flux<Station> {
+        return databaseClient.sql(
+            """
+                SELECT
+                    s.id AS station_id,
+                    s.name AS station_name,
+                    ls.station_code AS station_code,
+                    ls.fr_code AS fr_code,
+                    l.id AS line_id,
+                    l.name AS line_name,
+                    l.code AS line_code
+                FROM `line_stations` ls
+                INNER JOIN `stations` s ON s.id = ls.station_id
+                INNER JOIN `lines` l ON l.id = ls.line_id
+                WHERE l.name = ? OR l.code = ?
+                ORDER BY ls.id ASC
+            """.trimIndent()
+        )
+            .bind(0, lineKey)
+            .bind(1, lineKey)
+            .map { row, _ -> mapRow(row) }
+            .all()
+    }
+
+    private fun mapRow(row: Row): Station {
+        val stationId = row.get("station_id", java.lang.Long::class.java)!!
+        val stationName = row.get("station_name", String::class.java)!!
+        val stationCode = row.get("station_code", String::class.java)!!
+        val externalCode = row.get("fr_code", String::class.java)!!
+        val lineId = row.get("line_id", java.lang.Long::class.java)!!
+        val lineName = row.get("line_name", String::class.java)!!
+        val lineCode = row.get("line_code", String::class.java)!!
+
+        return Station(
+            id = stationId.toLong(),
+            name = stationName,
+            stationCode = stationCode,
+            externalCode = externalCode,
+            lineId = lineId.toLong(),
+            lineName = lineName,
+            lineCode = lineCode
+        )
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
@@ -1,0 +1,45 @@
+package click.metroeye.api.presentation.v1.controller
+
+import click.metroeye.api.application.service.StationService
+import click.metroeye.api.presentation.v1.dto.response.ApiResponse
+import click.metroeye.api.presentation.v1.dto.response.StationResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/v1/stations")
+@Tag(name = "Station API", description = "역 API")
+class StationController(
+    private val stationService: StationService
+) {
+    @Operation(
+        summary = "역 목록 조회 API",
+        method = "GET",
+        description = """
+*line 파라미터가 있으면 해당 호선의 역을 조회하고, 없으면 전체 역을 조회합니다.*
+### [Query Parameter]
+- **line**: 호선 ID/코드/이름 (예: 2, 02, 2호선)
+"""
+    )
+    @GetMapping
+    fun getStations(
+        @RequestParam(required = false) line: String?
+    ): Mono<ResponseEntity<ApiResponse<List<StationResponse>>>> {
+        return stationService.getStations(line)
+            .map { stationResponses ->
+                ResponseEntity.ok(
+                    ApiResponse(
+                        "조회되었습니다.",
+                        "SUCCESS",
+                        stationResponses
+                    )
+                )
+            }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/StationResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/StationResponse.kt
@@ -1,0 +1,15 @@
+package click.metroeye.api.presentation.v1.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "역 정보 응답 객체")
+data class StationResponse(
+    @field:Schema(description = "역 이름")
+    val name: String,
+    @field:Schema(description = "역 코드")
+    val stationCode: String,
+    @field:Schema(description = "호선 ID")
+    val lineId: Long,
+    @field:Schema(description = "호선 이름")
+    val lineName: String
+)


### PR DESCRIPTION
- 역 목록 조회를 위한 GET /v1/stations API를 개발

- line이 없을 경우 전체 역 목록을 반환하도록 구성

- stations, line_stations, lines 테이블을 조인해 역 정보와 호선 정보를 함께 조회하도록 구현

- station 조회는 조회 전용 로직으로 분리하고 StationQueryRepository로 정리

- 응답 데이터는 name, stationCode, lineId, lineName 중심으로 정리