### PR TITLE
[#116] Fix: 인증 필터 전역 등록 문제 해결 및 인증 예외 경로 설정

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/AuthService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/AuthService.kt
@@ -97,6 +97,18 @@ class AuthService(
                     serverMessage = "Refresh token subject is missing."
                 )
 
+                val tokenType = claims["type"] as? String ?: throw InvalidAuthException(
+                    errorCode = ErrorCode.INVALID_TOKEN,
+                    serverMessage = "Token type is missing."
+                )
+
+                if (tokenType != "REFRESH") {
+                    throw InvalidAuthException(
+                        errorCode = ErrorCode.INVALID_TOKEN,
+                        serverMessage = "Token is not an refresh token."
+                    )
+                }
+
                 deviceRepositoryAdapter.loadDevice(uuid)
                     .flatMap { loadedDevice ->
                         if (!loadedDevice.validateRefreshToken(refreshToken)) {

--- a/src/main/kotlin/click/metroeye/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/click/metroeye/api/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package click.metroeye.api.config
 
 import click.metroeye.api.constants.ErrorCode
 import click.metroeye.api.infrastructure.security.filter.BearerAuthenticationWebFilter
+import click.metroeye.api.infrastructure.security.manager.BearerAuthenticationManager
 import click.metroeye.api.presentation.v1.dto.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
@@ -46,18 +47,25 @@ class SecurityConfig {
     @Order(2)
     fun apiSecurityFilterChain(
         http: ServerHttpSecurity,
-        bearerAuthenticationWebFilter: BearerAuthenticationWebFilter,
+        bearerAuthenticationManager: BearerAuthenticationManager,
         objectMapper: ObjectMapper
     ): SecurityWebFilterChain {
+        val bearerAuthenticationWebFilter = BearerAuthenticationWebFilter(bearerAuthenticationManager, objectMapper)
+
         return http
-            .securityMatcher(ServerWebExchangeMatchers.pathMatchers(
-                "/v1/lines/**"
-            ))
+            .securityMatcher(
+                ServerWebExchangeMatchers.pathMatchers(
+                    "/v1/**"
+                )
+            )
             .csrf { it.disable() }
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
             .authorizeExchange {
-                it.anyExchange().authenticated()
+                it.pathMatchers(
+                    "/v1/devices/**",
+                    "/v1/auth/**"
+                ).permitAll().anyExchange().authenticated()
             }
             .exceptionHandling {
                 it.authenticationEntryPoint { exchange, exception ->

--- a/src/main/kotlin/click/metroeye/api/infrastructure/security/filter/BearerAuthenticationWebFilter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/security/filter/BearerAuthenticationWebFilter.kt
@@ -9,10 +9,8 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
-import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
 
-@Component
 class BearerAuthenticationWebFilter(
     private val bearerAuthenticationManager: BearerAuthenticationManager,
     private val objectMapper: ObjectMapper
@@ -28,7 +26,7 @@ class BearerAuthenticationWebFilter(
 
             val apiResponse = ApiResponse(
                 errorCode.clientMessage,
-                errorCode.serverMessage,
+                    exception.message ?: errorCode.serverMessage,
                 null
             )
 

--- a/src/main/kotlin/click/metroeye/api/infrastructure/security/manager/BearerAuthenticationManager.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/security/manager/BearerAuthenticationManager.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 import reactor.core.publisher.Mono
 
 @Component
-    class BearerAuthenticationManager(
+class BearerAuthenticationManager(
     private val jsonWebTokenAdapter: JsonWebTokenAdapter,
 
     @Value("\${jwt.secret}")


### PR DESCRIPTION
## 이슈 번호 (#116)

## 요약
- 인증 필터 클래스의 컴포넌트 어노테이션을 제거하고 시큐리티 설정 클래스에서 호출하는 것으로 변경
- 인증 예외 경로 추가
- 엑세스 토큰 갱신 시 누락된 예외 추가