### PR TITLE
[#136] Refactor: LogFilter Request Body 캐싱 방식 변경

### DIFF
--- a/src/main/kotlin/click/metroeye/api/filter/LogFilter.kt
+++ b/src/main/kotlin/click/metroeye/api/filter/LogFilter.kt
@@ -5,6 +5,9 @@ import click.metroeye.api.filter.decorator.CachedContentServerHttpResponse
 import click.metroeye.api.util.getClientIp
 import click.metroeye.api.util.toHeadersString
 import org.slf4j.LoggerFactory
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.http.MediaType
+import org.springframework.util.AntPathMatcher
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
@@ -13,45 +16,64 @@ import reactor.core.publisher.Mono
 class LogFilter : WebFilter {
     companion object {
         private val logger = LoggerFactory.getLogger(LogFilter::class.java)
+
+        private val loggingPaths = listOf(
+            "/v1/**"
+        )
+        private val antPathMatcher = AntPathMatcher()
     }
 
-    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void?> {
-        if (!exchange.request.uri.path.startsWith("/v1")) {
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        if (loggingPaths.none { antPathMatcher.match(it, exchange.request.uri.path) }) {
             return chain.filter(exchange)
         }
 
-        val cachingRequest = CachedContentServerHttpRequest(exchange.request)
-        val cachingResponse = CachedContentServerHttpResponse(exchange.response)
+        val requestBodyBytes: Mono<ByteArray> = if (exchange.request.headers.contentType?.includes(MediaType.APPLICATION_JSON) == true) {
+            DataBufferUtils.join(exchange.request.body)
+                .map { buffer ->
+                    val bytes = ByteArray(buffer.readableByteCount())
+                    buffer.read(bytes)
+                    DataBufferUtils.release(buffer)
+                    bytes
+                }
+                .defaultIfEmpty(ByteArray(0))
+        } else {
+            Mono.just(ByteArray(0))
+        }
 
-        val mutatedExchange = exchange.mutate()
-            .request(cachingRequest)
-            .response(cachingResponse)
-            .build()
-
-        return chain.filter(mutatedExchange)
-            .doFinally {
-                logger.info("""
+        return requestBodyBytes.flatMap { bytes ->
+            logger.info("""
             
             
-                    |[REQUEST]
-                    |>> METHOD: ${exchange.request.method}
-                    |>> REQUEST URI: ${exchange.request.uri.path}
-                    |>> CLIENT IP: ${exchange.request.headers.getClientIp()}
-                    |>> HEADERS: ${exchange.request.headers.toHeadersString()}
-                    |>> REQUEST PARAM: ${exchange.request.queryParams.takeIf { it.isNotEmpty() } ?: ""}
-                    |>> REQUEST BODY: ${cachingRequest.getCachedContent().replace(Regex("\\s+"), "").trim()}
-                    """.trimIndent()
-                )
+                |[REQUEST]
+                |>> METHOD: ${exchange.request.method}
+                |>> REQUEST URI: ${exchange.request.uri.path}
+                |>> CLIENT IP: ${exchange.request.headers.getClientIp()}
+                |>> HEADERS: ${exchange.request.headers.toHeadersString()}
+                |>> REQUEST PARAM: ${exchange.request.queryParams.takeIf { it.isNotEmpty() } ?: ""}
+                |>> REQUEST BODY: ${String(bytes, Charsets.UTF_8).replace(Regex("\\s+"), "").trim()}
+            """.trimIndent())
 
-                val status = exchange.response.statusCode?.value() ?: 200
+            val cachingRequest = CachedContentServerHttpRequest(exchange.request, bytes)
+            val cachingResponse = CachedContentServerHttpResponse(exchange.response)
+            val mutatedExchange = exchange.mutate()
+                .request(cachingRequest)
+                .response(cachingResponse)
+                .build()
 
-                logger.info("""
+            chain.filter(mutatedExchange)
+                .doFinally {
+                    val status = exchange.response.statusCode?.value()
+                    val isSuccessStatus = exchange.response.statusCode?.is2xxSuccessful ?: false
+
+                    logger.info("""
             
             
-                    |[RESPONSE]
-                    |>> STATUS: $status
-                    ${if (status != 200) "|>> RESPONSE BODY: ${cachingResponse.getCachedContent()}" else ""}   
+                        |[RESPONSE]
+                        |>> STATUS: $status
+                        ${if (!isSuccessStatus) "|>> RESPONSE BODY: ${cachingResponse.bodyAsString()}" else ""}   
                     """.trimIndent())
-            }
+                }
+        }
     }
 }

--- a/src/main/kotlin/click/metroeye/api/filter/decorator/CachedContentServerHttpRequest.kt
+++ b/src/main/kotlin/click/metroeye/api/filter/decorator/CachedContentServerHttpRequest.kt
@@ -1,51 +1,19 @@
 package click.metroeye.api.filter.decorator
 
 import org.springframework.core.io.buffer.DataBuffer
-import org.springframework.http.MediaType
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator
 import reactor.core.publisher.Flux
 
 class CachedContentServerHttpRequest(
-    delegate: ServerHttpRequest
+    delegate: ServerHttpRequest,
+    private val requestBodyBytes: ByteArray
 ) : ServerHttpRequestDecorator(delegate) {
-    companion object {
-        private const val MAX_CONTENT_LENGTH = 1024
-    }
-
-    private var cachedContent: String = ""
-    private var totalByteCount: Int = 0
-    private var isLoggable: Boolean = true
-
     override fun getBody(): Flux<DataBuffer> {
-        if (headers.contentType?.includes(MediaType.APPLICATION_JSON) != true) {
-            return super.getBody()
-        }
-
-        val stringBuffer = StringBuffer()
-
-        return super.getBody()
-            .map { buffer ->
-                if (!isLoggable) {
-                    return@map buffer
-                }
-
-                val byteCount = buffer.readableByteCount()
-
-                if (totalByteCount + byteCount > MAX_CONTENT_LENGTH) {
-                    isLoggable = false
-                    cachedContent = ""
-                    return@map buffer
-                }
-
-                totalByteCount += byteCount
-                val bytes = ByteArray(byteCount)
-                buffer.read(bytes)
-                stringBuffer.append(String(bytes, Charsets.UTF_8))
-                cachedContent = stringBuffer.toString()
-                buffer.factory().wrap(bytes)
-            }
+        if (requestBodyBytes.isEmpty()) return super.getBody()
+        return Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(requestBodyBytes))
     }
 
-    fun getCachedContent(): String = cachedContent
+    fun bodyAsString(): String = String(requestBodyBytes, Charsets.UTF_8)
 }

--- a/src/main/kotlin/click/metroeye/api/filter/decorator/CachedContentServerHttpResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/filter/decorator/CachedContentServerHttpResponse.kt
@@ -15,16 +15,15 @@ class CachedContentServerHttpResponse(
         private const val MAX_CONTENT_LENGTH = 1024
     }
 
-    private var cachedContent: String = ""
+    private val stringBuffer = StringBuffer()
+    private var responseBody: String = ""
     private var totalByteCount: Int = 0
     private var isLoggable: Boolean = true
 
-    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void?> {
+    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> {
         if (headers.contentType?.includes(MediaType.APPLICATION_JSON) != true) {
             return super.writeWith(body)
         }
-
-        val stringBuffer = StringBuffer()
 
         return super.writeWith(
             Flux.from(body)
@@ -37,7 +36,7 @@ class CachedContentServerHttpResponse(
 
                     if (totalByteCount + byteCount > MAX_CONTENT_LENGTH) {
                         isLoggable = false
-                        cachedContent = ""
+                        responseBody = ""
                         return@map buffer
                     }
 
@@ -45,11 +44,11 @@ class CachedContentServerHttpResponse(
                     val bytes = ByteArray(byteCount)
                     buffer.read(bytes)
                     stringBuffer.append(String(bytes, Charsets.UTF_8))
-                    cachedContent = stringBuffer.toString()
+                    responseBody = stringBuffer.toString()
                     buffer.factory().wrap(bytes)
                 }
         )
     }
 
-    fun getCachedContent(): String = cachedContent
+    fun bodyAsString(): String = responseBody
 }


### PR DESCRIPTION
## 이슈 번호 (#136)

## 요약
- CachedContentServerHttpRequest 클래스 내 requestBodyBytes 매개변수 추가
- LogFilter 클래스 filter 메서드에서 Request Body 값을 미리 읽도록 변경