### PR TITLE
[#144] Fix: 인접역 목록 API 종착역 노출 수정

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/StationService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/StationService.kt
@@ -41,8 +41,10 @@ class StationService(
         val stationsByCode = loadedStations.groupBy { it.code }
 
         val nextStationRoutes = traverseAdjacentStationRoutes(selectedStation.code, stationsByCode, DirectionType.NEXT, size)
+            .filter { it.isNotEmpty() }
             .map { (listOf(selectedStation.code) + it).reversed() }
         val prevStationRoutes = traverseAdjacentStationRoutes(selectedStation.code, stationsByCode, DirectionType.PREV, size)
+            .filter { it.isNotEmpty() }
             .map { listOf(selectedStation.code) + it }
 
 


### PR DESCRIPTION
## 이슈 번호 (#144)

## 요약
- traverseAdjacentStationRoutes 메서드 호출 후 filter 메서드 추가