### PR TITLE
feat: 실시간 열차 도착 정보 조회 API 추가

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/TrainService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/TrainService.kt
@@ -1,0 +1,36 @@
+package click.metroeye.api.application.service
+
+import click.metroeye.api.infrastructure.external.seoul.SeoulSubwayClientAdapter
+import click.metroeye.api.infrastructure.persistence.StationRepositoryAdapter
+import click.metroeye.api.presentation.v1.dto.response.TrainResponse
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class TrainService(
+    private val stationRepositoryAdapter: StationRepositoryAdapter,
+    private val seoulSubwayClientAdapter: SeoulSubwayClientAdapter
+) {
+    suspend fun getTrains(stationId: Long): List<TrainResponse>? {
+        val station = stationRepositoryAdapter.loadStationById(stationId) ?: return null
+
+        val apiResponse = seoulSubwayClientAdapter
+            .getRealtimeArrivalsByStation(1, 1000, station.name)
+            .awaitSingleOrNull() ?: return emptyList()
+
+        if (!apiResponse.success || apiResponse.data == null) return emptyList()
+
+        return apiResponse.data.map { arrival ->
+            TrainResponse(
+                updnLine = arrival.updnLine,
+                statnFid = arrival.statnFid,
+                statnTid = arrival.statnTid,
+                statnId = arrival.statnId,
+                btrainSttus = arrival.btrainSttus,
+                btrainNo = arrival.btrainNo,
+                arvlCd = arrival.arvlCd,
+                lstcarAt = arrival.lstcarAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package click.metroeye.api.infrastructure.persistence
 
 import click.metroeye.api.domain.Line
 import click.metroeye.api.domain.Station
+import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.stereotype.Repository
@@ -10,6 +11,45 @@ import org.springframework.stereotype.Repository
 class StationRepositoryAdapter(
     private val databaseClient: DatabaseClient
 ) {
+    suspend fun loadStationById(stationId: Long): Station? {
+        return databaseClient.sql(
+            """
+                SELECT
+                    s.id AS station_id,
+                    s.name AS station_name,
+                    ls.code AS station_code,
+                    ls.prev_code AS prev_code,
+                    ls.next_code AS next_code,
+                    ls.is_terminal AS is_terminal,
+                    l.id AS line_id,
+                    l.name AS line_name,
+                    l.color AS line_color
+                FROM `line_stations` AS ls
+                INNER JOIN `stations` AS s ON ls.station_id = s.id
+                INNER JOIN `lines` AS l ON ls.line_id = l.id
+                WHERE s.id = :stationId
+                LIMIT 1
+            """.trimIndent())
+            .bind("stationId", stationId)
+            .map { row ->
+                Station.of(
+                    id = row.get("station_id", Long::class.java)!!,
+                    name = row.get("station_name", String::class.java)!!,
+                    code = row.get("station_code", String::class.java)!!,
+                    prevCode = row.get("prev_code", String::class.java),
+                    nextCode = row.get("next_code", String::class.java),
+                    line = Line.of(
+                        id = row.get("line_id", Long::class.java)!!,
+                        name = row.get("line_name", String::class.java)!!,
+                        color = row.get("line_color", String::class.java)!!
+                    )
+                )
+            }
+            .all()
+            .next()
+            .awaitFirstOrNull()
+    }
+
     suspend fun loadStations(lineId: Long? = null): List<Station> {
         val bindParams = listOfNotNull(
             lineId?.let { "lineId" to it }

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
@@ -1,9 +1,11 @@
 package click.metroeye.api.presentation.v1.controller
 
 import click.metroeye.api.application.service.StationService
+import click.metroeye.api.application.service.TrainService
 import click.metroeye.api.presentation.v1.dto.response.AdjacentStationsResponse
 import click.metroeye.api.presentation.v1.dto.response.ApiResponse
 import click.metroeye.api.presentation.v1.dto.response.StationResponse
+import click.metroeye.api.presentation.v1.dto.response.TrainResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -21,7 +23,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/stations")
 @Tag(name = "Station API", description = "역 API")
 class StationController(
-    private val stationService: StationService
+    private val stationService: StationService,
+    private val trainService: TrainService
 ) {
     @Operation(
         summary = "역 목록 조회 API",
@@ -142,6 +145,68 @@ class StationController(
                 clientMessage = "조회되었습니다.",
                 serverMessage = "Success",
                 data = adjacentStationsResponses
+            )
+        )
+    }
+
+    @Operation(
+        summary = "실시간 열차 도착 정보 조회 API",
+        method = "GET",
+        description = """
+*역의 실시간 열차 도착 정보를 조회합니다.*
+
+### [Path Variable]
+
+- **stationId**: 역 ID
+"""
+    )
+    @ApiResponses(
+        value = [
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                value = """
+                                    {
+                                        "clientMessage": "조회되었습니다.",
+                                        "serverMessage": "SUCCESS",
+                                        "data": [
+                                            {
+                                                "updnLine": "0",
+                                                "statnFid": "1001000123",
+                                                "statnTid": "1001000125",
+                                                "statnId": "1001000124",
+                                                "btrainSttus": "일반",
+                                                "btrainNo": "1234",
+                                                "arvlCd": "2",
+                                                "lstcarAt": "0"
+                                            }
+                                        ]
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/{stationId}/trains")
+    suspend fun getTrains(
+        @Parameter(description = "역 ID", required = true)
+        @PathVariable(value = "stationId") stationId: Long
+    ): ResponseEntity<ApiResponse<List<TrainResponse>>> {
+        val trainResponses = trainService.getTrains(stationId)
+            ?: return ResponseEntity.notFound().build()
+
+        return ResponseEntity.ok(
+            ApiResponse(
+                clientMessage = "조회되었습니다.",
+                serverMessage = "Success",
+                data = trainResponses
             )
         )
     }

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/TrainResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/TrainResponse.kt
@@ -1,0 +1,23 @@
+package click.metroeye.api.presentation.v1.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "실시간 열차 도착 정보")
+data class TrainResponse(
+    @Schema(description = "상하행선 구분 (0: 상행, 1: 하행)")
+    val updnLine: String?,
+    @Schema(description = "이전 지하철역 ID")
+    val statnFid: String?,
+    @Schema(description = "다음 지하철역 ID")
+    val statnTid: String?,
+    @Schema(description = "현재 지하철역 ID")
+    val statnId: String?,
+    @Schema(description = "열차 종류 (급행, ITX, 일반, 특급)")
+    val btrainSttus: String?,
+    @Schema(description = "열차 번호")
+    val btrainNo: String?,
+    @Schema(description = "도착 코드 (0: 진입, 1: 도착, 2: 출발, 3: 전역출발, 4: 전역도착, 5: 전역진입)")
+    val arvlCd: String?,
+    @Schema(description = "막차 여부 (0: 막차 아님, 1: 막차)")
+    val lstcarAt: String?
+)


### PR DESCRIPTION
  - GET /v1/stations/{stationId}/trains 엔드포인트 추가
  - stationId(DB PK)로 역 이름을 조회 후 서울 공공 API 호출
  - updnLine, statnFid, statnTid, statnId, btrainSttus, btrainNo, arvlCd, lstcarAt 반환
  - StationRepositoryAdapter에 loadStationById 단건 조회 추가