### PR TITLE
feat: 실시간 열차 도착 정보 API lineId 필터링 추가 및 응답 필드 확장

### DIFF
--- a/src/main/kotlin/click/metroeye/api/application/service/TrainService.kt
+++ b/src/main/kotlin/click/metroeye/api/application/service/TrainService.kt
@@ -1,36 +1,71 @@
 package click.metroeye.api.application.service
 
+import click.metroeye.api.constants.ErrorCode
+import click.metroeye.api.exception.InvalidStationException
 import click.metroeye.api.infrastructure.external.seoul.SeoulSubwayClientAdapter
+import click.metroeye.api.infrastructure.persistence.LineRepositoryAdapter
 import click.metroeye.api.infrastructure.persistence.StationRepositoryAdapter
 import click.metroeye.api.presentation.v1.dto.response.TrainResponse
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class TrainService(
     private val stationRepositoryAdapter: StationRepositoryAdapter,
+    private val lineRepositoryAdapter: LineRepositoryAdapter,
     private val seoulSubwayClientAdapter: SeoulSubwayClientAdapter
 ) {
-    suspend fun getTrains(stationId: Long): List<TrainResponse>? {
-        val station = stationRepositoryAdapter.loadStationById(stationId) ?: return null
+    suspend fun getTrains(stationId: Long, lineId: Long): List<TrainResponse> {
+        val station = stationRepositoryAdapter.loadStationById(stationId)
+            ?: throw InvalidStationException(ErrorCode.STATION_NOT_FOUND)
 
-        val apiResponse = seoulSubwayClientAdapter
-            .getRealtimeArrivalsByStation(1, 1000, station.name)
-            .awaitSingleOrNull() ?: return emptyList()
-
-        if (!apiResponse.success || apiResponse.data == null) return emptyList()
-
-        return apiResponse.data.map { arrival ->
-            TrainResponse(
-                updnLine = arrival.updnLine,
-                statnFid = arrival.statnFid,
-                statnTid = arrival.statnTid,
-                statnId = arrival.statnId,
-                btrainSttus = arrival.btrainSttus,
-                btrainNo = arrival.btrainNo,
-                arvlCd = arrival.arvlCd,
-                lstcarAt = arrival.lstcarAt
-            )
+        if (!stationRepositoryAdapter.existsStationOnLine(stationId, lineId)) {
+            throw InvalidStationException(ErrorCode.STATION_LINE_NOT_MATCH)
         }
+
+        val line = lineRepositoryAdapter.loadLineById(lineId)
+            ?: throw InvalidStationException(ErrorCode.STATION_NOT_FOUND)
+
+        val (arrivalResponse, positionResponse) = coroutineScope {
+            val arrivals = async {
+                seoulSubwayClientAdapter
+                    .getRealtimeArrivalsByStation(1, 1000, station.name)
+                    .awaitSingleOrNull()
+            }
+            val positions = async {
+                seoulSubwayClientAdapter
+                    .getRealtimePositionsByLine(1, 1000, line.name)
+                    .awaitSingleOrNull()
+            }
+            arrivals.await() to positions.await()
+        }
+
+        val arrivals = arrivalResponse?.data ?: return emptyList()
+        val positionTrainNos = positionResponse?.data
+            ?.mapNotNull { it.trainNo }
+            ?.toSet()
+            ?: emptySet()
+
+        return arrivals
+            .filter { it.btrainNo != null && it.btrainNo in positionTrainNos }
+            .map { arrival ->
+                TrainResponse(
+                    subwayId = arrival.subwayId,
+                    updnLine = arrival.updnLine,
+                    statnFid = arrival.statnFid,
+                    statnTid = arrival.statnTid,
+                    statnId = arrival.statnId,
+                    btrainNo = arrival.btrainNo,
+                    btrainSttus = arrival.btrainSttus,
+                    barvlDt = arrival.barvlDt,
+                    bstatnNm = arrival.bstatnNm,
+                    arvlMsg2 = arrival.arvlMsg2,
+                    arvlMsg3 = arrival.arvlMsg3,
+                    arvlCd = arrival.arvlCd,
+                    lstcarAt = arrival.lstcarAt
+                )
+            }
     }
 }

--- a/src/main/kotlin/click/metroeye/api/constants/ErrorCode.kt
+++ b/src/main/kotlin/click/metroeye/api/constants/ErrorCode.kt
@@ -37,6 +37,21 @@ enum class ErrorCode(
         HttpStatus.INTERNAL_SERVER_ERROR
     ),
 
+    // 역
+    STATION_NOT_FOUND(
+        "STATION001",
+        "역 정보를 찾을 수 없습니다.",
+        "Station not found.",
+        HttpStatus.NOT_FOUND
+    ),
+
+    STATION_LINE_NOT_MATCH(
+        "STATION002",
+        "해당 역은 요청한 호선에 존재하지 않습니다.",
+        "Station does not belong to the requested line.",
+        HttpStatus.BAD_REQUEST
+    ),
+
     // 인증
     AUTHENTICATION_REQUIRED(
         "AUTH001",

--- a/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/click/metroeye/api/exception/ApiExceptionHandler.kt
@@ -31,6 +31,16 @@ class ApiExceptionHandler {
                         )
                     )
             }
+            is InvalidStationException -> {
+                ResponseEntity.status(e.errorCode.status)
+                    .body(
+                        ApiResponse(
+                            e.clientMessage,
+                            e.serverMessage,
+                            null
+                        )
+                    )
+            }
             else -> {
                 ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(

--- a/src/main/kotlin/click/metroeye/api/exception/InvalidStationException.kt
+++ b/src/main/kotlin/click/metroeye/api/exception/InvalidStationException.kt
@@ -1,0 +1,10 @@
+package click.metroeye.api.exception
+
+import click.metroeye.api.constants.ErrorCode
+
+class InvalidStationException(
+    val errorCode: ErrorCode
+) : RuntimeException(errorCode.serverMessage) {
+    val clientMessage: String = errorCode.clientMessage
+    val serverMessage: String = errorCode.serverMessage
+}

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/LineRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/LineRepositoryAdapter.kt
@@ -19,4 +19,10 @@ class LineRepositoryAdapter(
             )
         }
     }
+
+    suspend fun loadLineById(lineId: Long): Line? {
+        return lineRepository.findById(lineId)?.let { entity ->
+            Line.of(id = entity.id, name = entity.name, color = entity.color)
+        }
+    }
 }

--- a/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationRepositoryAdapter.kt
+++ b/src/main/kotlin/click/metroeye/api/infrastructure/persistence/StationRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import click.metroeye.api.domain.Line
 import click.metroeye.api.domain.Station
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.r2dbc.core.DatabaseClient
 import org.springframework.stereotype.Repository
 
@@ -48,6 +49,21 @@ class StationRepositoryAdapter(
             .all()
             .next()
             .awaitFirstOrNull()
+    }
+
+    suspend fun existsStationOnLine(stationId: Long, lineId: Long): Boolean {
+        return databaseClient.sql(
+            """
+                SELECT COUNT(*) AS cnt
+                FROM `line_stations` AS ls
+                INNER JOIN `stations` AS s ON ls.station_id = s.id
+                WHERE s.id = :stationId AND ls.line_id = :lineId
+            """.trimIndent())
+            .bind("stationId", stationId)
+            .bind("lineId", lineId)
+            .map { row -> row.get("cnt", Long::class.java)!! > 0 }
+            .one()
+            .awaitSingleOrNull() ?: false
     }
 
     suspend fun loadStations(lineId: Long? = null): List<Station> {

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/controller/StationController.kt
@@ -139,7 +139,6 @@ class StationController(
         @RequestParam(value = "size") size: Int,
     ): ResponseEntity<ApiResponse<List<AdjacentStationsResponse>>> {
         val adjacentStationsResponses = stationService.getAdjacentStations(lineId, stationId, size)
-
         return ResponseEntity.ok(
             ApiResponse(
                 clientMessage = "조회되었습니다.",
@@ -158,6 +157,10 @@ class StationController(
 ### [Path Variable]
 
 - **stationId**: 역 ID
+
+### [Query Parameter]
+
+- **lineId**: 호선 ID
 """
     )
     @ApiResponses(
@@ -197,11 +200,11 @@ class StationController(
     @GetMapping("/{stationId}/trains")
     suspend fun getTrains(
         @Parameter(description = "역 ID", required = true)
-        @PathVariable(value = "stationId") stationId: Long
+        @PathVariable(value = "stationId") stationId: Long,
+        @Parameter(description = "호선 ID", required = true)
+        @RequestParam(value = "lineId") lineId: Long
     ): ResponseEntity<ApiResponse<List<TrainResponse>>> {
-        val trainResponses = trainService.getTrains(stationId)
-            ?: return ResponseEntity.notFound().build()
-
+        val trainResponses = trainService.getTrains(stationId, lineId)
         return ResponseEntity.ok(
             ApiResponse(
                 clientMessage = "조회되었습니다.",

--- a/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/TrainResponse.kt
+++ b/src/main/kotlin/click/metroeye/api/presentation/v1/dto/response/TrainResponse.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "실시간 열차 도착 정보")
 data class TrainResponse(
+    @Schema(description = "지하철 호선 ID")
+    val subwayId: String?,
     @Schema(description = "상하행선 구분 (0: 상행, 1: 하행)")
     val updnLine: String?,
     @Schema(description = "이전 지하철역 ID")
@@ -12,10 +14,18 @@ data class TrainResponse(
     val statnTid: String?,
     @Schema(description = "현재 지하철역 ID")
     val statnId: String?,
-    @Schema(description = "열차 종류 (급행, ITX, 일반, 특급)")
-    val btrainSttus: String?,
     @Schema(description = "열차 번호")
     val btrainNo: String?,
+    @Schema(description = "열차 종류 (급행, ITX, 일반, 특급)")
+    val btrainSttus: String?,
+    @Schema(description = "열차 도착 예정 시간 (초)")
+    val barvlDt: String?,
+    @Schema(description = "종착 지하철역명")
+    val bstatnNm: String?,
+    @Schema(description = "첫번째 도착 메시지")
+    val arvlMsg2: String?,
+    @Schema(description = "두번째 도착 메시지")
+    val arvlMsg3: String?,
     @Schema(description = "도착 코드 (0: 진입, 1: 도착, 2: 출발, 3: 전역출발, 4: 전역도착, 5: 전역진입)")
     val arvlCd: String?,
     @Schema(description = "막차 여부 (0: 막차 아님, 1: 막차)")


### PR DESCRIPTION
- GET /v1/stations/{stationId}/trains에 lineId 쿼리 파라미터 추가
- 실시간 도착정보 API(역 이름)와 위치정보 API(호선 이름)를 병렬 호출하여 위치정보의 trainNo 기준으로 교차 필터링, 해당 호선 열차만 반환
- TrainResponse에 subwayId, barvlDt, bstatnNm, arvlMsg2, arvlMsg3 필드 추가
- LineRepositoryAdapter에 loadLineById 추가
- StationRepositoryAdapter에 existsStationOnLine 추가
- InvalidStationException 및 에러코드(STATION_NOT_FOUND, STATION_LINE_NOT_MATCH) 추가
- 존재하지 않는 stationId 입력 시 404, 유효하지 않은 역-호선 조합 시 400 반환